### PR TITLE
compiles with the latest 8.8 branch of paramcoq

### DIFF
--- a/theories/L4_deBruijn/L4_to_L4_2_correct.v
+++ b/theories/L4_deBruijn/L4_to_L4_2_correct.v
@@ -136,6 +136,8 @@ Proof using.
 Qed.
 
 
+Print Assumptions eval_evaln.
+
 Definition  eval41 := @polyEval.eval_n (TermAbsDBUnstrict Ast.name L4Opid).
 
 
@@ -421,7 +423,7 @@ Qed.
 
 
 Require Import Common.TermAbs_parametricity.
-Parametricity Recursive eval_n.
+Parametricity Recursive eval_n qualified.
 
 (* should be automatically provalble for all types with decidable equality.
   However, it cannot be internally stated. *)
@@ -429,10 +431,11 @@ Global Instance EqIfRdcon : EqIfR CertiCoq_o_L4_o_polyEval_o_dcon_R.
 Proof using.
 Admitted.
 
-Global Instance EqIfRstring : EqIfR string_R.
+Global Instance EqIfRstring : EqIfR Coq_o_Strings_o_String_o_string_R.
 Proof using.
 Admitted.
 
+Let L4Opid_R := CertiCoq_o_L4_o_polyEval_o_L4Opid_R.
 Global Instance EqIfRL4Opid : EqIfR L4Opid_R.
 Proof using.
   constructor; intros Hyp; subst.

--- a/theories/L4_deBruijn/L4_to_L4_2_correct.v
+++ b/theories/L4_deBruijn/L4_to_L4_2_correct.v
@@ -469,9 +469,9 @@ Proof using.
   specialize (Hp _ (conj Hfb (alpha_eq_refl _))).
   simpl in Hp.
   destruct (@eval_n (TermAbsDB Ast.name L4Opid) n t1).
-  - invertsna Hp Hp. setoid_rewrite <- Hp0.
+  - invertsna Hp Hp.  unfold tL4_1_to_L4_2. rewrite <- Hp0.
     constructor. tauto.
-  - invertsna Hp Hp. setoid_rewrite <- Hp.
+  - invertsna Hp Hp.  unfold tL4_1_to_L4_2. rewrite <- Hp.
     constructor.
 Qed.
 
@@ -491,9 +491,9 @@ Proof using.
   specialize (Hp _ (conj Hfb (alpha_eq_refl _))).
   simpl in Hp.
   destruct (@eval_n (TermAbsDBUnstrict Ast.name L4Opid) n t1).
-  - invertsna Hp Hp. setoid_rewrite <- Hp0.
+  - invertsna Hp Hp.  unfold tL4_1_to_L4_2. rewrite <- Hp0.
     constructor. tauto.
-  - invertsna Hp Hp. setoid_rewrite <- Hp.
+  - invertsna Hp Hp.  unfold tL4_1_to_L4_2. rewrite <- Hp.
     constructor.
 Qed.
 

--- a/theories/common/TermAbs_parametricity.v
+++ b/theories/common/TermAbs_parametricity.v
@@ -9,7 +9,7 @@ https://github.com/aa755/paramcoq/tree/v86
 *)
 Declare ML Module "paramcoq".
 Require Import Common.TermAbs.
-Parametricity Recursive TermAbs.
+Parametricity Recursive TermAbs qualified.
 Require Import SquiggleEq.bin_rels.
 Require Import SquiggleEq.eq_rel.
 Require Import SquiggleEq.universe.
@@ -45,6 +45,10 @@ Inductive list_RP {A₁ A₂ : Type} (A_R : A₁ -> A₂ -> Prop) : list A₁ ->
                     forall (H1 : list A₁) (H2 : list A₂),
                     list_RP  A_R H1 H2 -> list_RP A_R (H :: H1) (H0 :: H2).
 
+Definition list_R := Coq_o_Init_o_Datatypes_o_list_R.
+Definition option_R := Coq_o_Init_o_Datatypes_o_option_R.
+Definition nat_R := Coq_o_Init_o_Datatypes_o_nat_R.
+Definition prod_R := Coq_o_Init_o_Datatypes_o_prod_R.
 Lemma list_RP_same (A₁ A₂ : Type) (A_R : A₁ -> A₂ -> Prop) : forall l1 l2,
   t_iff (list_R _ _ A_R l1 l2) (list_RP A_R l1 l2).
 Proof using.
@@ -181,7 +185,10 @@ Context {Name NVar VarClass Opid : Type} {deqv vcc fvv}
   `{vartyp: @VarType NVar VarClass deqv vcc fvv}
   `{deqo: Deq Opid} {gts : GenericTermSig Opid} (def:Name).
 
-Definition TermAbs_R_NamedAlphaClosedWf Opid_R {Hoeq: @EqIfR Opid Opid_R}:
+Let TermAbs_R:= CertiCoq_o_Common_o_TermAbs_o_TermAbs_R.
+Let TermAbs_R_Build_TermAbs_R := CertiCoq_o_Common_o_TermAbs_o_TermAbs_R_Build_TermAbs_R.
+
+Definition TermAbs_R_NamedAlphaClosedWf Opid_R {Hoeq: @EqIfR Opid Opid_R}: 
 TermAbs_R Opid Opid Opid_R
     (Named.TermAbsImplUnstrict NVar Opid)
     (Named.TermAbsImplUnstrict NVar Opid).


### PR DESCRIPTION
This version uses the "qualified" option for the generated
parametricity theorems, which prevents name clash issues, as explained here:
https://github.com/aa755/paramcoq/pull/3

I have made a new release for the latest state of the 8.8 branch:
https://github.com/aa755/paramcoq/releases/tag/v1.0.8