### PR TITLE
Rewriter metacoq

### DIFF
--- a/theories/L6_PCPS/Frame.v
+++ b/theories/L6_PCPS/Frame.v
@@ -1,0 +1,8 @@
+(* One layer of a 1-hole context *)
+Class Frame (U : Set) := {
+  (* The type to poke holes in + all its transitive dependencies *)
+  univD : U -> Set;
+  (* Frames, indexed by hole type + root type *)
+  frame_t : U -> U -> Set;
+  (* Frame application *)
+  frameD : forall {A B : U}, frame_t A B -> univD A -> univD B }.

--- a/theories/L6_PCPS/MockExpr.v
+++ b/theories/L6_PCPS/MockExpr.v
@@ -1,0 +1,33 @@
+From CertiCoq.L6 Require Import PrototypeGenFrame.
+
+Require Import Coq.Strings.String.
+
+Require Import Coq.Lists.List.
+Import ListNotations.
+
+From MetaCoq Require Import Template.All.
+
+(* Unset Strict Unquote Universe Mode. *)
+
+Definition var := nat.
+Definition constr := nat.
+Inductive exp :=
+| eHalt (x : var)
+| eApp (f : var) (xs : list var)
+| eCons (x : var) (c : constr) (ys : list var) (e : exp) (* let x = c ys in e *)
+| eProj (x : var) (y : var) (n : nat) (e : exp)
+| eCase (x : var) (arms : list (constr × exp))
+| eFuns (fds : list fundef) (e : exp)
+with fundef := fFun (f : var) (xs : list var) (e : exp).
+
+Run TemplateProgram (mk_Frame_ops "exp" exp [var; constr; nat; list var]).
+
+Print exp_univ.
+Print exp_univD.
+Print exp_frame_t.
+Print exp_frameD.
+Print exp_Frame_ops.
+Print exp_aux_data.
+
+Instance Frame_exp : Frame exp_univ := exp_Frame_ops.
+Instance AuxData_exp : AuxData exp_univ := exp_aux_data.

--- a/theories/L6_PCPS/Prototype.v
+++ b/theories/L6_PCPS/Prototype.v
@@ -1,0 +1,1910 @@
+Require Import Coq.Strings.Ascii Coq.Strings.String.
+Infix "+++" := append (at level 60, right associativity).
+
+Require Import Coq.Lists.List.
+Import ListNotations.
+
+From MetaCoq Require Import Template.All.
+Import MonadNotation.
+Module TM := MetaCoq.Template.monad_utils.
+
+From ExtLib.Core Require Import RelDec.
+From ExtLib.Data Require Import Nat List Option Pair String.
+From ExtLib.Structures Require Import Monoid Functor Applicative Monads Traversable.
+From ExtLib.Data.Monads Require Import IdentityMonad EitherMonad StateMonad.
+
+Require Import Coq.NArith.BinNat.
+Local Open Scope N_scope.
+
+Require Import Coq.Relations.Relations.
+
+Require Import Ltac2.Ltac2.
+Import Ltac2.Notations.
+Set Default Proof Mode "Ltac2".
+
+Set Universe Polymorphism.
+
+Require Export CertiCoq.L6.Rewriting.
+Require Export CertiCoq.L6.PrototypeGenFrame.
+
+(* -------------------- Converting between named and indices --------------------
+   Indices are a real pain for some of the things we want to do.
+   Hack: quoted ASTs will never contain names starting with $, so we're free to use
+   names like $1, $2, and $3 internally. So, to stay sane, we'll use tVar + nNamed
+   binders for naming.
+   Before unquoting, all internally generated names will be replaced by the proper
+   indices. *)
+
+Fail Run TemplateProgram (tmUnquote (tLambda (nNamed "$oof") <%nat%> (tRel 0))).
+
+Definition gensym (suffix : string) : GM string :=
+  let! n := get in
+  let! _ := modify (fun n => 1 + n) in
+  ret (string_of_N n +++ "$" +++ suffix).
+
+Definition add_sigils (x : name) : GM string :=
+  match x with
+  | nAnon => gensym ""
+  | nNamed s => gensym s
+  end.
+
+Fixpoint remove_sigils (s : string) : name :=
+  match s with
+  | EmptyString => nNamed s
+  | "$" => nAnon
+  | String "$" s => nNamed s
+  | String _ s => remove_sigils s
+  end.
+
+Fixpoint remove_sigils' (s : string) : string :=
+  match s with
+  | EmptyString => s
+  | "$" => ""
+  | String "$" s => s
+  | String _ s => remove_sigils' s
+  end.
+
+Definition named_of (Γ : list string) (tm : term) : GM term :=
+  let fix go (n : nat) (Γ : list string) (tm : term) : GM term :=
+    match n with O => raise "named_of: OOF" | S n =>
+      let go := go n in
+      let go_mfix mfix : GM (mfixpoint term) :=
+        let! names := mapM (fun d => add_sigils d.(dname)) mfix in
+        let Γ' := rev names ++ Γ in
+        mapM
+          (fun '(s, d) =>
+            mkdef _ (nNamed s)
+              <$> go Γ d.(dtype)
+              <*> go Γ' d.(dbody)
+              <*> ret d.(rarg))
+          (combine names mfix)
+      in
+      match tm with
+      | tRel n => tVar <$> nthM_nat n Γ
+      | tVar id => ret tm
+      | tEvar ev args => ret tm
+      | tSort s => ret tm
+      | tCast t kind v => tCast <$> go Γ t <*> ret kind <*> go Γ v
+      | tProd na ty body =>
+        let! s := add_sigils na in
+        tProd (nNamed s) <$> go Γ ty <*> go (s :: Γ) body
+      | tLambda na ty body =>
+        let! s := add_sigils na in
+        tLambda (nNamed s) <$> go Γ ty <*> go (s :: Γ) body
+      | tLetIn na def def_ty body =>
+        let! s := add_sigils na in
+        tLetIn (nNamed s) <$> go Γ def <*> go Γ def_ty <*> go (s :: Γ) body
+      | tApp f args => mkApps <$> go Γ f <*> mapM (go Γ) args
+      | tConst c u => ret tm
+      | tInd ind u => ret tm
+      | tConstruct ind idx u => ret tm
+      | tCase ind_and_nbparams type_info discr branches =>
+        tCase ind_and_nbparams
+          <$> go Γ type_info <*> go Γ discr
+          <*> mapM (fun '(n, t) => pair n <$> go Γ t) branches
+      | tProj proj t => tProj proj <$> go Γ t
+      | tFix mfix idx => tFix <$> go_mfix mfix <*> ret idx
+      | tCoFix mfix idx => tCoFix <$> go_mfix mfix <*> ret idx
+      end
+    end
+  in go 1000%nat Γ tm.
+
+(*
+Compute runGM' 0 (named_of [] <%
+  fun x y z w : nat =>
+  match x, y with
+  | S x, S y => z * x + y * w
+  | O, y => z + z
+  | _, _ => w
+  end%nat%>).
+Compute runGM' 0 (named_of [] <%forall x y z : nat, x = y -> y = z -> x = z%>).
+*)
+
+Definition find_str (s : string) (ss : list string) : GM nat :=
+  let fix go n ss :=
+    match ss with
+    | [] => raise ("find_str: " +++ s)
+    | s' :: ss => if s ==? s' then ret n else go (S n) ss
+    end
+  in go O ss.
+
+Definition indices_of (Γ : list string) (t : term) : GM term :=
+  let index_of Γ s := find_str s Γ in
+  let go_name (x : name) : (name × string) :=
+    match x with
+    | nAnon => (nAnon, "anon") (* can never be referred to in named rep, so don't care if there are clashes *)
+    | nNamed s => (remove_sigils s, s)
+    end
+  in
+  let fix go (n : nat) (Γ : list string) (tm : term) : GM term :=
+    match n with O => raise "named_of: OOF" | S n =>
+      let go := go n in
+      let go_mfix mfix : GM (mfixpoint term) :=
+        let nass := map (fun d => go_name d.(dname)) mfix in
+        let '(names, strings) := split nass in
+        let Γ' := rev strings ++ Γ in
+        mapM
+          (fun '(na, d) =>
+            mkdef _ na
+              <$> go Γ d.(dtype)
+              <*> go Γ' d.(dbody)
+              <*> ret d.(rarg))
+          (combine names mfix)
+      in
+      match tm with
+      | tRel n => ret tm
+      | tVar id => tRel <$> index_of Γ id
+      | tEvar ev args => ret tm
+      | tSort s => ret tm
+      | tCast t kind v => tCast <$> go Γ t <*> ret kind <*> go Γ v
+      | tProd na ty body =>
+        let '(na, s) := go_name na in tProd na <$> go Γ ty <*> go (s :: Γ) body
+      | tLambda na ty body =>
+        let '(na, s) := go_name na in tLambda na <$> go Γ ty <*> go (s :: Γ) body
+      | tLetIn na def def_ty body =>
+        let '(na, s) := go_name na in tLetIn na <$> go Γ def <*> go Γ def_ty <*> go (s :: Γ) body
+      | tApp f args => mkApps <$> go Γ f <*> mapM (go Γ) args
+      | tConst c u => ret tm
+      | tInd ind u => ret tm
+      | tConstruct ind idx u => ret tm
+      | tCase ind_and_nbparams type_info discr branches =>
+        tCase ind_and_nbparams
+          <$> go Γ type_info <*> go Γ discr
+          <*> mapM (fun '(n, t) => pair n <$> go Γ t) branches
+      | tProj proj t => tProj proj <$> go Γ t
+      | tFix mfix idx => tFix <$> go_mfix mfix <*> ret idx
+      | tCoFix mfix idx => tCoFix <$> go_mfix mfix <*> ret idx
+      end
+    end
+  in go 1000%nat [] t.
+
+Definition check_roundtrip (Γ : list string) (t : term) : GM (option (term × term)) :=
+  let! named := named_of Γ t in
+  let! t' := indices_of Γ named in
+  ret (if string_of_term t ==? string_of_term t' then None else Some (t, t')).
+
+Compute runGM' 0 (check_roundtrip [] <%
+  fun x y z w : nat =>
+  match x, y with
+  | S x, S y => z * x + y * w
+  | O, y => z + z
+  | _, _ => w
+  end%nat%>).
+Compute runGM' 0 (check_roundtrip [] <%forall x y z : nat, x = y -> y = z -> x = z%>).
+Compute runGM' 0 (check_roundtrip [] <%
+  fix ev n :=
+    match n with
+    | 0 => true
+    | S n => odd n
+    end%nat
+  with odd n :=
+    match n with
+    | 0 => false
+    | S n => ev n
+    end%nat
+  for ev%>).
+
+(* Renames binders too, and doesn't respect scoping rules at all *)
+Definition rename (σ : Map string string) : term -> term :=
+  let go_str (s : string) : string := find_d s s σ in
+  let go_name (na : name) : name :=
+    match na with
+    | nAnon => na
+    | nNamed id => nNamed (go_str id)
+    end
+  in
+  fix go (tm : term) : term :=
+    let go_mfix (mfix : list (def term)) : list (def term) :=
+      map (fun '(mkdef f ty body rarg) => mkdef _ (go_name f) (go ty) (go body) rarg) mfix
+    in
+    match tm with
+    | tRel n => tm
+    | tVar id => tVar (go_str id)
+    | tEvar ev args => tEvar ev (map go args)
+    | tSort s => tm
+    | tCast t kind v => tCast (go t) kind (go v)
+    | tProd na ty body => tProd (go_name na) (go ty) (go body)
+    | tLambda na ty body => tLambda (go_name na) (go ty) (go body)
+    | tLetIn na def def_ty body => tLetIn (go_name na) (go def) (go def_ty) (go body)
+    | tApp f args => mkApps (go f) (map go args)
+    | tConst c u => tm
+    | tInd ind u => tm
+    | tConstruct ind idx u => tm
+    | tCase ind_and_nbparams type_info discr branches =>
+      tCase ind_and_nbparams (go type_info) (go discr) (map (on_snd go) branches)
+    | tProj proj t => tProj proj (go t)
+    | tFix mfix idx => tFix (go_mfix mfix) idx
+    | tCoFix mfix idx => tCoFix (go_mfix mfix) idx
+    end.
+
+(* -------------------- Generation of helper function types -------------------- *)
+
+(* The type of rewriters (AuxData and typeclass instances needed by generator) *)
+Definition rewriter {U} `{H : Frame U} `{AuxData U} (Root : U) (fueled : bool)
+           (metric : Metric Root fueled)
+           (Rstep : relation (univD Root))
+           (D : Set) (I_D : forall (A : U), univD A -> D -> Prop)
+           `{@Delayed _ H _ I_D}
+           (R : Set) (I_R : forall (A : U), frames_t A Root -> R -> Prop)
+           (S : Set) (I_S : forall (A : U), frames_t A Root -> univD A -> S -> Prop)
+           `{@Preserves_R _ H _ _ I_R}
+           `{@Preserves_S_dn _ H _ _ I_S}
+           `{@Preserves_S_up _ H _ _ I_S}
+  : Type := rewriter' fueled metric Rstep (I_D:=I_D) I_R I_S.
+
+(* ---------- Flags to aid in proof saerch ---------- *)
+
+(* For each rule, *)
+Inductive ExtraVars (s : string) : Prop := MkExtraVars.
+Inductive RunRule (s : string) : Prop := MkRunRule.
+Inductive Success (s : string) : Prop := MkSuccess.
+Inductive Failure (s : string) : Prop := MkFailure.
+
+(* For each constructor, *)
+Inductive ConstrDelay {A} (c : A) : Prop := MkConstrDelay.
+Inductive SmartConstr {A} (c : A) : Prop := MkSmartConstr.
+Inductive SmartConstrCase {A} (e : A) : Prop := MkSmartConstrCase.
+
+(* For each nonatomic type, *)
+Inductive Topdown {A} (u : A) : Prop := MkTopdown.
+Inductive Bottomup {A} (u : A) : Prop := MkBottomup.
+Inductive InspectCaseRule (s : string) : Prop := MkInspectCaseRule.
+Inductive InspectCaseCongruence {A} (c : A) : Prop := MkInspectCaseCongruence.
+Inductive Active (s : string) : Prop := MkActive.
+Inductive Congruence {A} (c : A) : Prop := MkCongruence.
+Inductive Fallback : Prop := MkFallback.
+Inductive Impossible : Prop := MkImpossible.
+
+Record RwObligations A := mk_obs {
+  (* For each rule, *)
+  obExtraVars : list A;
+  obRunRules : list A;
+  (* For each constructor, *)
+  obConstrDelays : list A;
+  obSmartConstrs : list A;
+  (* For each nonatomic type, *)
+  obTopdowns : list A;
+  obBottomups : list A }.
+Arguments mk_obs {_}.
+
+(* ---------- MetaCoq helpers ---------- *)
+
+Fixpoint quote_pos (n : positive) : term :=
+  match n with
+  | xH => <%xH%>
+  | xI n => mkApps <%xI%> [quote_pos n]
+  | xO n => mkApps <%xO%> [quote_pos n]
+  end.
+
+Definition quote_N (n : N) : term :=
+  match n with
+  | N0 => <%N0%>
+  | Npos n => mkApps <%Npos%> [quote_pos n]
+  end.
+
+Definition quote_nat (n : nat) : term :=
+  Nat.iter n (fun t => mkApps <%S%> [t]) <%O%>.
+
+Definition quote_bool (b : bool) : term := if b then <%true%> else <%false%>.
+
+Definition quote_char (c : ascii) : term :=
+  match c with
+  | Ascii x x0 x1 x2 x3 x4 x5 x6 =>
+    tApp <%Ascii%> (map quote_bool [x; x0; x1; x2; x3; x4; x5; x6])
+  end.
+
+Fixpoint quote_string (s : string) : term :=
+  match s with
+  | EmptyString => <%EmptyString%>
+  | String c s => tApp <%String%> [quote_char c; quote_string s]
+  end.
+
+Run TemplateProgram (tmPrint =<< tmUnquote (quote_string "abc")).
+
+(* abbreviate = map head . splitOn "_" *)
+Fixpoint abbreviate s :=
+  let fix skip_to_underscore s := 
+    match s with
+    | "" => s
+    | String "_" s => abbreviate s
+    | String _ s => skip_to_underscore s
+    end
+  in
+  match s with
+  | "" => s
+  | String "_" s => abbreviate s
+  | String c s => String c (skip_to_underscore s)
+  end.
+Compute abbreviate "list_var".
+
+Fixpoint vars_of (t : term) : Set' string :=
+  match t with
+  | tRel n => empty
+  | tVar id => sing id tt
+  | tEvar ev args => union_all (map vars_of args)
+  | tSort s => empty
+  | tCast t kind v => vars_of t ∪ vars_of v
+  | tProd na ty body => vars_of ty ∪ vars_of body
+  | tLambda na ty body => vars_of ty ∪ vars_of body
+  | tLetIn na def def_ty body => vars_of def ∪ vars_of def_ty ∪ vars_of body
+  | tApp f args => vars_of f ∪ union_all (map vars_of args)
+  | tConst c u => empty
+  | tInd ind u => empty
+  | tConstruct ind idx u => empty
+  | tCase ind_and_nbparams type_info discr branches =>
+    vars_of type_info ∪ vars_of discr ∪ union_all (map (fun '(_, t) => vars_of t) branches)
+  | tProj proj t => vars_of t
+  | tFix mfix idx => union_all (map (fun def => vars_of def.(dtype) ∪ vars_of def.(dbody)) mfix)
+  | tCoFix mfix idx => union_all (map (fun def => vars_of def.(dtype) ∪ vars_of def.(dbody)) mfix)
+  end.
+
+(* ---------- Parsing the inductive relation ---------- *)
+
+Definition named_ctx := list (string × context_decl).
+
+Definition named_of_context (Γ : context) : GM named_ctx :=
+  foldrM
+    (fun d m =>
+      match d.(decl_name) with
+      | nAnon => raise "named_of_context: nAnon"
+      | nNamed s => ret ((s, d) :: m)
+      end)
+    []
+    Γ.
+
+Definition drop_names : named_ctx -> context := map snd.
+
+Inductive rule_direction := dTopdown | dBottomup.
+Definition path_step := (string × list term) × nat.
+Record rule_t := mk_rule {
+  rName : string;
+  rType : term;
+  rArity : nat;
+  rDir : rule_direction;
+  rHoleU : nat; (* index into the inductive type rw_univ *)
+  rΓ : named_ctx; (* 
+   C can only be used to construct Props.
+   - C : A replaced by C : erased A.
+   - Each assumption H : P where C ∈ FV(P) replaced by H : «e_map (fun C => P) C». *)
+  rC : term;
+  rLhs : term;
+  rRhs : term;
+  rLhsVars : Set' string;
+  rRecVars : Map string (option term); (* Each variable associated with function call pending at that node *)
+  rSpecialVars : Map string (option term); }.
+Record rules_t := mk_rules {
+  rR : inductive;
+  rRules : list rule_t;
+  rUniv : inductive;
+  rRootU : nat;
+  rHFrame : term; }.
+
+Definition ctor_ty := (string × term) × nat.
+Definition ctors_ty := list ctor_ty.
+
+Section GoalGeneration.
+
+(* Check if a term is a variable if you strip off casts *)
+Fixpoint is_var (x : term) : option string :=
+  match x with
+  | tVar x => Some x
+  | tCast x _ _ => is_var x
+  | _ => None
+  end.
+
+(* Rec (f .. x) *)
+(* NOTE: This is a hack and depends on the _CoqProject file+name of this file *)
+Compute <%@Rec%>.
+Definition prefix := ltac:(
+   let e := constr:(<%@Rec%>) in
+   match e with
+   | tConst ?s [] => let s' := eval cbv in (qualifier s) in exact s'
+   end).
+Print prefix.
+Definition rec_rhs_vars_of : term -> Map string (option term).
+  ltac1:(refine(
+  let fix go tm :=
+    match tm with
+    | tApp (tConstruct _ _ _) args => union_all (map go args)
+    | tApp (tConst func []) args =>
+      if func ==? (prefix +++ "Rec") then
+        match args with
+        | [_A; x] =>
+          match is_var x with
+          | Some x => sing x None
+          | None =>
+            match x with
+            | tApp (tConstruct _ _ _) _ => empty
+            | tApp f ((x :: _) as xs) =>
+              match is_var (last xs x) with
+              | Some x => sing x (Some (tApp f (removelast xs)))
+              | None => empty
+              end
+            | _ => empty
+            end
+          end
+        | _ => empty
+        end
+      else empty
+    | _ => empty
+    end
+  in go
+)).
+Defined.
+
+(* Does x occur in non-binding position? *)
+Fixpoint has_var (x : BasicAst.ident) (e : term) {struct e} : bool. ltac1:(refine(
+  match e with
+  | tRel n => false
+  | tVar x' => x ==? x'
+  | tEvar ev args => anyb (has_var x) args
+  | tSort s => false
+  | tCast t kind v => has_var x t || has_var x v
+  | tProd na ty body => has_var x ty || has_var x body
+  | tLambda na ty body => has_var x ty || has_var x body
+  | tLetIn na def def_ty body => has_var x def || has_var x def_ty || has_var x body
+  | tApp f args => has_var x f || anyb (has_var x) args
+  | tConst c u => false
+  | tInd ind u => false
+  | tConstruct ind idx u => false
+  | tCase ind_and_nbparams type_info discr branches =>
+    has_var x type_info || has_var x discr || anyb (fun '(_, e) => has_var x e) branches
+  | tProj proj t => has_var x t
+  | tFix mfix idx => anyb (fun d => has_var x d.(dtype) || has_var x d.(dbody)) mfix
+  | tCoFix mfix idx => anyb (fun d => has_var x d.(dtype) || has_var x d.(dbody)) mfix
+  end%bool
+)).
+Defined.
+
+Definition erase_ctx (C : BasicAst.ident) (Cdecl : context_decl) (Γ : named_ctx) : named_ctx. ltac1:(refine(
+  map (fun '(C', d) =>
+   if C ==? C' then
+     (C, mkdecl d.(decl_name) d.(decl_body) (mkApps <%erased%> [d.(decl_type)]))
+   else if has_var C d.(decl_type) : bool then
+     let erased_ty :=
+       mkApps <%recover%> [mkApps <%@e_map%> [
+         Cdecl.(decl_type); <%Prop%>;
+         tLambda (nNamed C) Cdecl.(decl_type) d.(decl_type);
+         tVar C]]
+     in
+     (C', mkdecl d.(decl_name) d.(decl_body) erased_ty)
+   else (C', d)) Γ
+)).
+Defined.
+
+Definition rule_of_ind_ctor (ind_ctor : ctor_ty) : GM rule_t. ltac1:(refine(
+  let '(name, ctor_ty, arity) := ind_ctor in
+  let! ctor_ty :=
+    let! name := gensym name in
+    named_of [name] ctor_ty
+  in
+  let '(Γ, rty) := decompose_prod_assum [] ctor_ty in
+  let! Γ := named_of_context Γ in
+  match rty with
+  (* Topdown rule *)
+  | tApp (tVar _) [
+      tApp (tConst framesD1 []) [
+        _univ; _HFrame; tConstruct _univ_ind hole_ut []; _root_univ_ty; tVar C_var as C; lhs];
+      tApp (tConst framesD2 []) [_; _; _; _; _; rhs]] =>
+    let lhs_vars := vars_of lhs in
+    let rec_vars := rec_rhs_vars_of rhs in
+    let special_vars := rec_vars in (*∩ lhs_vars in*)
+    let! Cdecl := findM C_var Γ in
+    ret (mk_rule name ctor_ty arity dTopdown hole_ut (erase_ctx C_var Cdecl Γ) C lhs rhs
+      lhs_vars rec_vars special_vars)
+  (* Bottomup rule *)
+  | tApp (tConst _BottomUp []) [_; tApp (tVar _) [
+      tApp (tConst _framesD []) [
+        _univ; _HFrame; tConstruct _univ_ind hole_ut []; _root_univ_ty; tVar C_var as C; lhs];
+      tApp (tConst _ []) [_; _; _; _; _; rhs]]] =>
+    let lhs_vars := vars_of lhs in
+    let rec_vars := rec_rhs_vars_of rhs in
+    let special_vars := rec_vars ∩ lhs_vars in
+    let! Cdecl := findM C_var Γ in
+    ret (mk_rule name ctor_ty arity dBottomup hole_ut (erase_ctx C_var Cdecl Γ) C lhs rhs
+      lhs_vars rec_vars special_vars)
+  | rty => raise ("rule_of_ind_ctor: " +++ string_of_term rty)
+  end
+)).
+Defined.
+
+Definition parse_rel_pure (ind : inductive) (mbody : mutual_inductive_body)
+           (body : one_inductive_body) : GM rules_t. ltac1:(refine(
+  let! rules :=
+    mapiM
+      (fun i ctor => rule_of_ind_ctor ctor)
+      body.(ind_ctors)
+  in
+  match rules with
+  | [] => raise "parse_rel: empty relation"
+  | {| rΓ := Γ; rC := tVar C |} :: _ =>
+    let! Cty := findM C Γ in
+    match Cty.(decl_type) with
+    | tApp (tConst _erased []) [
+        tApp (tConst _frames_t []) [
+          tInd univ []; HFrame; _hole; tConstruct _univ root []]] =>
+      ret (mk_rules ind rules univ root HFrame)
+    | _ => raise ("parse_rel: C's type illformed: " +++ string_of_term Cty.(decl_type))
+    end
+  | _ :: _ => raise "parse_rel: C not tRel"
+  end
+)).
+Defined.
+
+Definition parse_rel {A} (ind : A) : TemplateMonad rules_t :=
+  ind <- tmQuote ind ;;
+  match ind with
+  | tInd ind [] =>
+    mbody <- tmQuoteInductive ind.(inductive_mind) ;;
+    match mbody.(ind_bodies) with
+    | [body] => runGM (parse_rel_pure ind mbody body)
+    | _ => tmFail "rel_constr_types: relation has more than one body"
+    end
+  | _ => tmFail "rel_constr_types: not an inductive relation"
+  end.
+
+End GoalGeneration.
+
+Ltac runGM n m k :=
+  let res := eval cbv in (runGM' n m) in
+  match res with
+  | inl ?e => fail 10 "runGM:" e
+  | inr (?x, ?n) => k x n
+  end.
+
+Ltac parse_rel n R k :=
+  run_template_program (
+    ind <- tmQuote R ;;
+    match ind with
+    | tInd ind [] =>
+      mbody <- tmQuoteInductive ind.(inductive_mind) ;;
+      match mbody.(ind_bodies) with
+      | [body] => ret (ind, mbody, body)
+      | _ => tmFail "rel_constr_types: relation has more than one body"
+      end
+    | _ => tmFail "rel_constr_types: not an inductive relation"
+    end) ltac:(fun pack =>
+  match pack with
+  | (?ind, ?mbody, ?body) =>
+    runGM n (parse_rel_pure ind mbody body) k
+  end).
+
+(* ---------- Types of helpers for computing preconditions/intermediate values ---------- *)
+
+Section GoalGeneration.
+
+Context
+  (aux_data : aux_data_t)
+  (typename := aux_data.(aTypename))
+  (ind_info := aux_data.(aIndInfo))
+  (graph := aux_data.(aGraph))
+  (univ_of_tyname := aux_data.(aUnivOfTyname))
+  (frames_of_constr := aux_data.(aFramesOfConstr)).
+Context
+  (rules : rules_t)
+  (rw_univ := rules.(rUniv))
+  (HFrame := rules.(rHFrame))
+  (root := rules.(rRootU))
+  (* specialize to univD rw_univ -> univD rw_univ -> Set *)
+  (frames_t := mkApps <%@frames_t%> [tInd rw_univ []; HFrame])
+  (* specialize to rw_univ -> Set *)
+  (univD := mkApps <%@univD%> [tInd rw_univ []; HFrame]) 
+  (mk_univ := fun n => tConstruct rw_univ n []).
+Context
+  (D I_D R I_R S I_S : term)
+  (Delay := mkApps <%@Delay%> [tInd rw_univ []; HFrame; D; I_D])
+  (Param := mkApps <%@Param%> [tInd rw_univ []; HFrame; mk_univ root; R; I_R])
+  (State := mkApps <%@State%> [tInd rw_univ []; HFrame; mk_univ root; S; I_S]).
+Context (delayD : term) (* specialized to forall {A} (e : univD A), Delay e -> univD A *).
+
+Definition gen_extra_vars_ty (rule : rule_t) : GM term :=
+  match rule.(rDir) with
+  | dTopdown =>
+    let hole := rule.(rHoleU) in
+    let lhs := rule.(rLhs) in
+    let lhs_vars := rule.(rLhsVars) in
+    (* Currently, the context rΓ contains (lhs vars ∪ rhs vars) in unspecified order.
+       We will rearrange it to be (lhs vars .. rhs vars ..). *)
+    let ctx := map (fun '(x, decl) => (member x lhs_vars, x, decl)) rule.(rΓ) in
+    let '(lhs_ctx, rhs_ctx) := partition (fun '(in_lhs, _, _) => in_lhs) ctx in
+    (* rhs_ctx also contains C: C will actually be introduced in the outer scope
+       already. We'll just borrow its name. *)
+    let! C :=
+      match rule.(rC) with
+      | tVar C => ret C
+      | t => raise ("gen_extra_vars_ty: expected tVar, got: " +++ string_of_term t)
+      end
+    in
+    (* Filter to drop C *)
+    let rhs_ctx := filter (fun '(_, x, decl) => negb (x ==? C)) rhs_ctx in
+    let rhs_ctx := map (fun '(_, x, decl) => (x, decl)) rhs_ctx in
+    let! Ans := gensym "Ans" in
+    let! C_ok := gensym "C_ok" in
+    let! d := gensym "d" in
+    let! r := gensym "r" in
+    let! s := gensym "s" in
+    let hole := mk_univ hole in
+    let root := mk_univ root in
+    let rule_name := quote_string rule.(rName) in
+    let rΓ := filter (fun '(x, decl) => negb (x ==? C)) rule.(rΓ) in
+    let! '(extra_vars, σ) :=
+      let Γ := map_of_list rΓ in
+      mfoldM
+        (fun x fn_call '(extras, σ) =>
+          let! x' := gensym (remove_sigils' x) in
+          let! md' := if member x rule.(rSpecialVars) then Some <$> gensym "d" else ret None in
+          let! decl := findM' x Γ "special_var" in
+          let ty := decl.(decl_type) in
+          let! tyname := mangle ind_info ty in
+          let! univ_n := findM' tyname univ_of_tyname "applicable: univ_n" in
+          let u := mk_univ (N.to_nat univ_n) in
+          ret ((x, fn_call, x', md', ty, u) :: extras, insert x x' σ))
+        ([], empty) (rule.(rSpecialVars) ∪ (map (fun '(s, _) => (s, None)) rule.(rLhsVars)))
+    in
+    let lhs' := rename σ rule.(rLhs) in
+    let ctx_ty := mkApps frames_t [hole; root] in
+    ret (fn (mkApps <%ExtraVars%> [rule_name])
+      (tProd (nNamed Ans) type0 
+      (tProd (nNamed C) (mkApps <%erased%> [ctx_ty])
+      (tProd (nNamed C_ok) (mkApps <%@e_ok%> [ctx_ty; tVar C])
+      (fold_right
+        (fun '(x, fn_call, x', md', xty, u) ty =>
+          if member x rule.(rLhsVars)
+          then tProd (nNamed x') xty ty
+          else ty)
+        (tProd (nNamed d) (mkApps Delay [hole; lhs'])
+        (tProd (nNamed r) (mkApps Param [hole; tVar C])
+        (tProd (nNamed s) (mkApps State [hole; tVar C; mkApps delayD [hole; lhs'; tVar d]])
+        (fn (fn (mkApps <%Success%> [rule_name])
+          (fold_right
+            (fun '(x, fn_call, x', md', xty, u) ty =>
+              (if member x rule.(rLhsVars) then tProd (nNamed x) xty else tProd (nNamed x') xty)
+              match md' with
+              | Some d' => tProd (nNamed d') (mkApps Delay [u; tVar x']) ty
+              | None => ty
+              end)
+            (it_mkProd_or_LetIn (drop_names rhs_ctx)
+            (fn (mkApps <%@eq%> [mkApps univD [hole]; mkApps delayD [hole; lhs'; tVar d]; rule.(rLhs)])
+            (fold_right
+              (fun '(x, fn_call, x', md', xty, u) ty =>
+                match md' with
+                | Some d' =>
+                  let lhs :=
+                    match fn_call with
+                    | Some fn_call => mkApps fn_call [tVar x]
+                    | None => tVar x
+                    end
+                  in
+                  fn (mkApps <%@eq%> [xty; lhs; mkApps delayD [u; tVar x'; tVar d']]) ty
+                | None => ty
+                end)
+              (fn (mkApps Param [hole; tVar C]) (fn (mkApps State [hole; tVar C; rule.(rRhs)]) (tVar Ans)))
+              extra_vars)))
+            extra_vars))
+        (fn (fn (mkApps <%Failure%> [rule_name]) (tVar Ans))
+        (tVar Ans))))))
+        extra_vars)))))
+  | dBottomup =>
+    let hole := rule.(rHoleU) in
+    let lhs := rule.(rLhs) in
+    let rhs := rule.(rRhs) in
+    let lhs_vars := rule.(rLhsVars) in
+    (* Currently, the context rΓ contains (lhs vars ∪ rhs vars) in unspecified order.
+       We will rearrange it to be (lhs vars .. rhs vars ..). *)
+    let ctx := map (fun '(x, decl) => (member x lhs_vars, x, decl)) rule.(rΓ) in
+    let '(lhs_ctx, rhs_ctx) := partition (fun '(in_lhs, _, _) => in_lhs) ctx in
+    (* rhs_ctx also contains C: C will actually be introduced in the outer scope
+       already. We'll just borrow its name. *)
+    let! C :=
+      match rule.(rC) with
+      | tVar C => ret C
+      | t => raise ("gen_extra_vars_ty: expected tVar, got: " +++ string_of_term t)
+      end
+    in
+    (* Filter to drop C *)
+    let rhs_ctx := filter (fun '(_, x, decl) => negb (x ==? C)) rhs_ctx in
+    let! Ans := gensym "Ans" in
+    let! C_ok := gensym "C_ok" in
+    let! r := gensym "r" in
+    let! s := gensym "s" in
+    let hole := mk_univ hole in
+    let root := mk_univ root in
+    let rule_name := quote_string rule.(rName) in
+    let ctx_ty := mkApps frames_t [hole; root] in
+    ret (fn (mkApps <%ExtraVars%> [rule_name])
+      (tProd (nNamed Ans) type0 
+      (tProd (nNamed C) (mkApps <%erased%> [ctx_ty])
+      (tProd (nNamed C_ok) (mkApps <%@e_ok%> [ctx_ty; tVar C])
+      (fold_right
+        (fun '(_, s, d) ty => tProd (nNamed s) d.(decl_type) ty)
+         (tProd (nNamed r) (mkApps Param [hole; tVar C])
+         (tProd (nNamed s) (mkApps State [hole; tVar C; lhs])
+         (fn
+           (fn (mkApps <%Success%> [rule_name]) (fold_right
+             (fun '(_, s, d) ty => tProd (nNamed s) d.(decl_type) ty)
+             (fn (mkApps Param [hole; tVar C]) (fn (mkApps State [hole; tVar C; rhs]) (tVar Ans)))
+             (rev rhs_ctx)))
+           (fn (fn (mkApps <%Failure%> [rule_name]) (tVar Ans)) (tVar Ans)))))
+        (rev lhs_ctx))))))
+  end.
+
+Definition gen_extra_vars_tys : GM (list term) :=
+  mapM
+    (fun r => let! ty := gen_extra_vars_ty r in indices_of [] ty)
+    (* (fun r => gen_extra_vars_ty r) *)
+    rules.(rRules).
+
+End GoalGeneration.
+
+(* ---------- Types of helpers for taking a single step ---------- *)
+
+Section GoalGeneration.
+
+Context
+  (rules : rules_t)
+  (rw_rel := tInd rules.(rR) [])
+  (rw_univ_i := rules.(rUniv))
+  (rw_univ := tInd rw_univ_i [])
+  (mk_univ := fun n => tConstruct rw_univ_i n [])
+  (HFrame := rules.(rHFrame))
+  (root := mk_univ rules.(rRootU)).
+Context (fueled metric : term).
+Context
+  (R I_R S I_S : term)
+  (Param := mkApps <%@Param%> [tInd rw_univ_i []; HFrame; root; R; I_R])
+  (State := mkApps <%@State%> [tInd rw_univ_i []; HFrame; root; S; I_S])
+  (* specialize to univD rw_univ -> univD rw_univ -> Set *)
+  (frames_t := mkApps <%@frames_t%> [tInd rw_univ_i []; HFrame])
+  (* specialize to Fuel fueled -> forall A, erased (frames_t A root) -> univD A -> Set *)
+  (rw_for := mkApps <%@rw_for%> [rw_univ; HFrame; root; fueled; metric; rw_rel; R; I_R; S; I_S]).
+
+Definition gen_run_rule_ty (r : rule_t) : GM term. ltac1:(refine(
+  let! emetric := gensym "emetric" in
+  let! fuel := gensym "fuel" in
+  let! C_ok := gensym "C_ok" in
+  let hole := mk_univ r.(rHoleU) in
+  ret
+    (fn (mkApps <%RunRule%> [quote_string r.(rName)])
+    (tProd (nNamed fuel) (mkApps <%Fuel%> [fueled])
+    (it_mkProd_or_LetIn (drop_names r.(rΓ))
+    (tProd (nNamed C_ok) (mkApps <%@e_ok%> [mkApps frames_t [hole; root]; r.(rC)])
+    (fn (mkApps Param [hole; r.(rC)])
+    (fn (mkApps State [hole; r.(rC); r.(rRhs)])
+    (fn (mkApps rw_for [tVar fuel; hole; r.(rC); r.(rRhs)])
+    (mkApps rw_for [tVar fuel; hole; r.(rC); r.(rLhs)]))))))))
+)).
+Defined.
+
+Definition gen_run_rule_tys : GM (list term) :=
+  mapM (fun t => let! t := gen_run_rule_ty t in indices_of [] t) rules.(rRules).
+
+End GoalGeneration.
+
+(* ---------- Types of helpers for incrementalizing delayed computation ---------- *)
+
+Section GoalGeneration.
+
+Context
+  (aux_data : aux_data_t)
+  (decls := aux_data.(aEnv))
+  (typename := aux_data.(aTypename)) (g := aux_data.(aGraph))
+  (univ_of_tyname := aux_data.(aUnivOfTyname)).
+Context
+  (rules : rules_t)
+  (rw_univ := rules.(rUniv))
+  (HFrame := rules.(rHFrame))
+  (root := rules.(rRootU))
+  (mk_univ := fun n => tConstruct rw_univ n []).
+Context
+  (D I_D : term)
+  (Delay := mkApps <%@Delay%> [tInd rw_univ []; HFrame; D; I_D]).
+Context
+  (delayD : term) (* specialized to forall {A}, univD A -> delay_t -> univD A *).
+
+Definition gen_constr_delay_ty (c : string) : GM term. ltac1:(refine(
+  let! '(n, children, rtyname) := findM c g.(mgChildren) in
+  let! rty := findM rtyname g.(mgTypes) in
+  let! '(ind, pars) := decompose_ind decls rty in
+  let ctr := mkApps (tConstruct ind (N.to_nat n) []) pars in
+  let univ_name := typename +++ "_univ" in
+  let! univ_n := findM rtyname univ_of_tyname in
+  let univ := tConstruct (mkInd univ_name 0) (N.to_nat univ_n) [] in
+  let! children :=
+    mapM
+      (fun tyname =>
+        let! ty := findM tyname g.(mgTypes) in
+        let! old := gensym (abbreviate tyname) in
+        let! univ_n := findM tyname univ_of_tyname in
+        let univ := tConstruct (mkInd univ_name 0) (N.to_nat univ_n) [] in
+        let atomic := member tyname g.(mgAtoms) in
+        let! new := if atomic then gensym (abbreviate tyname) else gensym "d" in
+        ret (tyname, old, new, ty, univ, atomic))
+      children
+  in
+  let! Ans := gensym "Ans" in
+  let! d := gensym "d" in
+  let ctr_ty := fold_right (fun '(_, _, _, ty, _, _) res => fn ty res) rty children in 
+  let before_delayD := mkApps ctr (map (fun '(_, old, _, _, _, _) => tVar old) children) in
+  ret (fn (mkApps <%@ConstrDelay%> [ctr_ty; ctr]) (tProd (nNamed Ans) type0
+    (fold_right
+      (fun '(_, old, _, ty, _, _) res => tProd (nNamed old) ty res)
+      (tProd (nNamed d) (mkApps Delay [univ; before_delayD])
+      (fn
+        (fold_right
+          (fun '(_, old, new, ty, univ, atomic) res =>
+            tProd (nNamed new) (if (atomic : bool) then ty else mkApps Delay [univ; tVar old]) res)
+          (fn
+            (mkApps <%@eq%> [rty;
+               mkApps delayD [univ; before_delayD; tVar d];
+               mkApps ctr (map
+                 (fun '(tyname, old, new, ty, _, atomic) => 
+                   if atomic : bool then tVar new
+                   else
+                     let n := find_d tyname 0 univ_of_tyname in
+                     let univ := tConstruct (mkInd univ_name 0) (N.to_nat n) [] in
+                     mkApps delayD [univ; tVar old; tVar new])
+                 children)])
+            (tVar Ans))
+          children)
+        (tVar Ans)))
+      children)))
+)).
+Defined.
+
+Definition gen_constr_delay_tys : GM (list term) :=
+  let constrs :=
+    fold_right
+      (fun '(_, cs) m =>
+         fold_right (fun c m => insert c tt m) m cs)
+      empty
+      (list_of_map g.(mgConstrs))
+  in
+  mapM
+    (fun constr => let! ty := gen_constr_delay_ty constr in indices_of [] ty)
+    (map fst (list_of_map constrs)).
+
+End GoalGeneration.
+
+(* ---------- Types of smart constructors ---------- *)
+
+Section GoalGeneration.
+
+Context
+  (aux_data : aux_data_t)
+  (decls := aux_data.(aEnv))
+  (typename := aux_data.(aTypename)) (graph := aux_data.(aGraph))
+  (univ_of_tyname := aux_data.(aUnivOfTyname))
+  (frames_of_constr := aux_data.(aFramesOfConstr)).
+Context
+  (rules : rules_t)
+  (rw_rel := tInd rules.(rR) [])
+  (rw_univ_i := rules.(rUniv))
+  (rw_univ := tInd rules.(rUniv) [])
+  (mk_univ := fun n => tConstruct rw_univ_i n [])
+  (HFrame := rules.(rHFrame))
+  (root := mk_univ rules.(rRootU)).
+Context (fueled metric : term).
+Context
+  (R I_R S I_S : term)
+  (Param := mkApps <%@Param%> [tInd rw_univ_i []; HFrame; root; R; I_R])
+  (State := mkApps <%@State%> [tInd rw_univ_i []; HFrame; root; S; I_S]).
+Context
+  (* specialize to rw_univ -> rw_univ -> Set *)
+  (frames_t := mkApps <%@frames_t%> [rw_univ; HFrame])
+  (* specialize to rw_univ -> Set *)
+  (univD := mkApps <%@univD%> [rw_univ; HFrame]) 
+  (* specialize to Fuel fueled -> forall A, erased (frames_t A root) -> univD A -> Set *)
+  (rw_for := mkApps <%@rw_for%> [rw_univ; HFrame; root; fueled; metric; rw_rel; R; I_R; S; I_S])
+  (frame_ind := mkInd (typename +++ "_frame_t") 0)
+  (frame_t := tInd frame_ind [])
+  (frame_cons := fun n => tConstruct frame_ind n [])
+  (univ_ind := mkInd (typename +++ "_univ") 0)
+  (univ_cons := fun n => tConstruct univ_ind n [])
+  (* Specialized to forall A B C, frame_t A B -> frames_t B C -> frames_t A C *)
+  (frames_cons := mkApps <%@frames_cons%> [rw_univ; frame_t]).
+
+Definition gen_smart_constr_ty (c : string) : GM term. ltac1:(refine(
+  let! '(n_constr, child_tys, rty) := findM' c graph.(mgChildren) "children" in
+  let n_constr := N.to_nat n_constr in
+  let! rty_term := findM' rty graph.(mgTypes) "types" in
+  let! '(ind, pars) := decompose_ind decls rty_term in
+  let constr := mkApps (tConstruct ind n_constr []) pars in
+  let frames := find_d c [] frames_of_constr in
+  let n_frames := map hIndex frames in
+  let get_univ_of ty :=
+    let! n := findM' ty univ_of_tyname "univ_of_tyname" in
+    ret (univ_cons (N.to_nat n))
+  in
+  let! univ_rty := get_univ_of rty in
+  let! xtys := mapM (fun ty => let! x := gensym (abbreviate ty) in ret (x, ty)) child_tys in
+  let! xutfs :=
+    mapM
+      (fun '(n, (lxtys, (x, ty), rxtys)) =>
+        let lxs := map fst lxtys in
+        let rxs := map fst rxtys in
+        let! univ := get_univ_of ty in
+        let! ty_term := findM ty graph.(mgTypes) in
+        ret (x, univ, ty_term, frame_cons n, lxs, rxs))
+      (combine n_frames (holes_of xtys))
+  in
+  let! fuel := gensym "fuel" in
+  let! C := gensym "C" in
+  let! C_ok := gensym "C_ok" in
+  let C_ty := mkApps frames_t [univ_rty; root] in
+  let constr_ty := fold_right (fun '(_, _, ty, _, _, _) res => fn ty res) rty_term xutfs in 
+  ret (fn (mkApps <%@SmartConstr%> [constr_ty; constr])
+    (tProd (nNamed fuel) (mkApps <%Fuel%> [fueled])
+    (tProd (nNamed C) (mkApps <%erased%> [C_ty])
+    (tProd (nNamed C_ok) (mkApps <%@e_ok%> [C_ty; tVar C])
+    (fold_right
+      (fun '(x, _, t, _, _, _) ty => tProd (nNamed x) t ty)
+      (fold_right
+        (fun '(x, u, t, f, lxs, rxs) ty =>
+          fn
+            (fn
+              (mkApps <%@SmartConstrCase%> [
+                rty_term; mkApps <%@frameD%> [
+                  rw_univ; HFrame; u; univ_rty;
+                  mkApps f (map tVar (lxs ++ rxs)); tVar x]])
+              (fold_right
+                (fun '(x', _, t, _, _, _) ty => if x ==? x' then ty else tProd (nNamed x') t ty)
+                (let mk_ctx_t u := mkApps frames_t [u; root] in
+                 mkApps rw_for [
+                   tVar fuel;
+                   u; mkApps <%@e_map%> [
+                     mk_ctx_t univ_rty; mk_ctx_t u;
+                     tLambda (nNamed C) (mk_ctx_t univ_rty) (mkApps frames_cons [
+                       u; univ_rty; root; 
+                       mkApps f (map tVar (lxs ++ rxs)); tVar C]);
+                     tVar C];
+                   tVar x])
+                xutfs))
+            ty)
+        (mkApps rw_for [
+          tVar fuel;
+          univ_rty; tVar C; 
+          mkApps constr (map (fun '(x, _, _, _, _, _) => tVar x) xutfs)])
+        (rev xutfs))
+      xutfs)))))
+)).
+Defined.
+
+Definition gen_smart_constr_tys : GM (list term) :=
+  let constrs :=
+    fold_right
+      (fun '(_, cs) m =>
+         fold_right (fun c m => insert c tt m) m cs)
+      empty
+      (list_of_map graph.(mgConstrs))
+  in
+  mapM
+    (fun constr => let! ty := gen_smart_constr_ty constr in indices_of [] ty)
+    (map fst (list_of_map constrs)).
+
+End GoalGeneration.
+
+(* ---------- Types of pattern matching combinators ---------- *)
+
+Fixpoint unwords (ws : list string) : string :=
+  match ws with
+  | [] => ""
+  | [s] => s
+  | s :: ss => s +++ " " +++ unwords ss
+  end.
+
+(* Elaborate a single pattern match
+     match e1, e2, .. with
+     | c x (d y ..) .., pat2, .. => success
+     | _ => failure
+     end : ret_ty
+   into the case tree
+     match e with
+     | c x fresh .. =>
+       match fresh with
+       | d y .. =>
+         match e2 with
+         | pat2 => ..
+         | .. => failure
+         end
+       | ..
+       | .. => failure
+       end
+     | ..
+     | .. => failure
+     end *)
+
+Definition gen_case_tree (ind_info : ind_info) (epats : list (term × term))
+           (ret_ty success failure : term) : GM term. ltac1:(refine(
+  let find_ind ind := findM' ind.(inductive_mind) ind_info "find_ind" in
+  let fix go F epats :=
+    match F with O => raise "gen_case_tree: OOF" | S F =>
+      let go := go F in
+      let go_pat e ind n_constr args epats :=
+        let! '(mbody, inds, _) := find_ind ind in
+        let! body := nthM_nat ind.(inductive_ind) mbody.(ind_bodies) in
+        let nparams := mbody.(ind_npars) in
+        let pars := firstn nparams args in
+        let args := skipn nparams args in
+        let! constrs :=
+          mapM
+            (fun '(name, constr_ty, arity) =>
+              let '(xs, ts, rty) := decompose_prod constr_ty in
+              let xs := skipn nparams xs in
+              let ts := skipn nparams ts in
+              let constr_ty := fold_right (fun '(x, t) ty => tProd x t ty) rty (combine xs ts) in
+              let constr_ty := subst0 (rev pars ++ rev_map (fun ind => tInd ind []) inds) constr_ty in
+              let! constr_ty := named_of [] constr_ty in
+              ret (name, constr_ty, arity))
+            body.(ind_ctors)
+        in
+        tCase (ind, nparams) (tLambda nAnon (mkApps (tInd ind []) pars) ret_ty) e <$>
+          mapiM_nat
+            (fun i '(_, constr_ty, arity) =>
+              let '(xs, ts, rty) := decompose_prod constr_ty in
+              let! xs :=
+                if i ==? n_constr then
+                  mapM
+                    (fun '(x, arg) =>
+                      match x, arg with
+                      | nAnon, _ => raise "gen_case_tree: name anon"
+                      | _, tVar x => ret x
+                      | nNamed x, _ => ret x
+                      end)
+                    (combine xs args)
+                else
+                  mapM
+                    (fun x =>
+                      match x with
+                      | nAnon => raise "gen_case_tree: name anon"
+                      | nNamed x => ret x
+                      end)
+                    xs
+              in
+              let! arm :=
+                 if i ==? n_constr
+                 then go (combine (map tVar xs) args ++ epats)
+                 else ret failure
+              in
+              let arm :=
+                fold_right
+                  (fun '(x, t) arm => tLambda (nNamed x) t arm)
+                  arm (combine xs ts)
+              in
+              ret (arity, arm))
+            constrs
+      in
+      match epats with
+      | [] => ret success
+      | (e, tConstruct ind n_constr []) :: epats => go_pat e ind n_constr [] epats
+      | (e, tApp (tConstruct ind n_constr []) args) :: epats => go_pat e ind n_constr args epats
+      | (e, tVar _) :: epats => go epats
+      | (_, pat) :: _ => raise ("gen_case_tree: bad pat: " +++ string_of_term pat)
+      end
+    end
+  in go 100%nat epats
+)).
+Defined.
+
+Section GoalGeneration.
+
+Context
+  (aux_data : aux_data_t)
+  (decls := aux_data.(aEnv))
+  (typename := aux_data.(aTypename))
+  (ind_info := aux_data.(aIndInfo))
+  (graph := aux_data.(aGraph))
+  (univ_of_tyname := aux_data.(aUnivOfTyname))
+  (frames_of_constr := aux_data.(aFramesOfConstr)).
+Context
+  (rules : rules_t)
+  (rw_rel := tInd rules.(rR) [])
+  (rw_univ_i := rules.(rUniv))
+  (rw_univ := tInd rw_univ_i [])
+  (mk_univ := fun n => tConstruct rw_univ_i n [])
+  (HFrame := rules.(rHFrame))
+  (root := mk_univ rules.(rRootU))
+  (* specialize to univD rw_univ -> univD rw_univ -> Set *)
+  (frames_t := mkApps <%@frames_t%> [rw_univ; HFrame])
+  (* specialize to rw_univ -> Set *)
+  (univD := mkApps <%@univD%> [rw_univ; HFrame]).
+Context
+  (D I_D R I_R S I_S : term)
+  (Delay := mkApps <%@Delay%> [tInd rw_univ_i []; HFrame; D; I_D])
+  (Param := mkApps <%@Param%> [tInd rw_univ_i []; HFrame; root; R; I_R])
+  (State := mkApps <%@State%> [tInd rw_univ_i []; HFrame; root; S; I_S]).
+Context (delayD : term) (* specialized to forall {A} (e : univD A), Delay e -> univD A *).
+
+Definition gen_topdown_ty (t_univ_i : N) : GM term. ltac1:(refine(
+  let n_univs := mfold (fun u n m => insert n u m) empty univ_of_tyname in
+  let! t_tyname := findM'' t_univ_i n_univs "t_univ_i" in
+  let t_univ_i := N.to_nat t_univ_i in
+  let! t_ty := findM' t_tyname graph.(mgTypes) "t_tyname" in
+  let! '(ind, pars) := decompose_ind decls t_ty in
+  let! Ans := gensym "Ans" in
+  let! d := gensym "d" in
+  let! C := gensym "C" in
+  let! C_ok := gensym "C_ok" in
+  let! e := gensym (abbreviate t_tyname) in
+  let! r := gensym "r" in
+  let! s := gensym "s" in
+  let t_univ := mk_univ t_univ_i in
+  let! constrs := findM' t_tyname graph.(mgConstrs) "t_tyname" in
+  let! congruences :=
+    mapM
+      (fun c =>
+        let! '(index, arg_tynames, rty) := findM' c graph.(mgChildren) "constr" in
+        let! xts :=
+          mapM
+            (fun tyname =>
+              let atomic := member tyname graph.(mgAtoms) in
+              let abbrev_tyname := abbreviate tyname in
+              let! x := gensym abbrev_tyname in
+              let! x' := gensym abbrev_tyname in
+              let! md := if atomic then ret None else Some <$> gensym "d" in
+              let! t := findM tyname graph.(mgTypes) in
+              let! univ_n := findM tyname univ_of_tyname in
+              let u := mk_univ (N.to_nat univ_n) in
+              ret (md, x, x', t, u))
+            arg_tynames
+        in
+        let! rty := findM rty graph.(mgTypes) in
+        let constr := mkApps (tConstruct ind (N.to_nat index) []) pars in
+        let constr_ty := fold_right (fun '(_, _, _, t, _) res => fn t res) rty xts in
+        let pat := mkApps constr (map (fun '(_, x, _, _, _) => tVar x) xts) in
+        let! header :=
+          gen_case_tree ind_info [(tVar e, pat)] type0
+            (mkApps <%@Congruence%> [constr_ty; constr])
+            <%Impossible%>
+        in
+        ret (fn (mkApps <%@InspectCaseCongruence%> [constr_ty; constr]) (fn header
+          (fold_right
+            (fun '(md, x, x', t, u) ty =>
+              tProd (nNamed x) t
+              (match md with
+               | Some d => tProd (nNamed d) (mkApps Delay [u; tVar x]) ty
+               | None => tProd (nNamed x') t ty
+               end))
+            (fn
+              (mkApps <%@eq%> [rty;
+                mkApps delayD [t_univ; tVar e; tVar d];
+                mkApps constr (map
+                  (fun '(md, x, x', t, u) =>
+                    match md with
+                    | None => tVar x'
+                    | Some d => mkApps delayD [u; tVar x; tVar d]
+                    end)
+                  xts)])
+              (fn
+                (mkApps <%@eq%> [rty; 
+                  tVar e;
+                  mkApps constr (map (fun '(md, x, x', t, u) => tVar x) xts)])
+                (tVar Ans)))
+            xts))))
+      constrs
+  in
+  let applicable :=
+    filter
+      (fun r => match r.(rDir) with dTopdown => r.(rHoleU) ==? t_univ_i | dBottomup => false end)
+      rules.(rRules)
+  in
+  let! applicable :=
+    mapM
+      (fun r =>
+        (* We can't reuse the trick of borrowing the name for C, because this type will have
+           multiple continuations corresponding to multiple rules with different names for C.
+           So in each rule we have to replace its personal name for C with the C in the outer
+           scope. *)
+        let! localC :=
+          match r.(rC) with
+          | tVar C => ret C
+          | t => raise ("gen_extra_vars_ty: expected tVar, got: " +++ string_of_term t)
+          end
+        in
+        let rΓ := filter (fun '(x, decl) => negb (x ==? localC)) r.(rΓ) in
+        let σ := sing localC C in
+        let rΓ := map (on_snd (map_decl (rename σ))) rΓ in
+        let! '(extra_vars, σ) :=
+          let Γ := map_of_list rΓ in
+          mfoldM
+            (fun x fn_call '(extras, σ) =>
+              let! x' := gensym (remove_sigils' x) in
+              let! md' := if member x r.(rSpecialVars) then Some <$> gensym "d" else ret None in
+              let! decl := findM' x Γ "special_var" in
+              let ty := decl.(decl_type) in
+              let! tyname := mangle ind_info ty in
+              let! univ_n := findM' tyname univ_of_tyname "applicable: univ_n" in
+              let u := mk_univ (N.to_nat univ_n) in
+              ret ((x, fn_call, x', md', ty, u) :: extras, insert x x' σ))
+            ([], empty) (r.(rSpecialVars) ∪ map (fun '(x, _) => (x, None)) r.(rLhsVars))
+        in
+        let old_lhs := rename σ r.(rLhs) in
+        let! header :=
+          gen_case_tree ind_info [(tVar e, r.(rLhs))] type0 
+            (mkApps <%Active%> [quote_string r.(rName)])
+            <%Impossible%>
+        in
+        ret (fn (mkApps <%InspectCaseRule%> [quote_string r.(rName)]) (fn header
+          (it_mkProd_or_LetIn (drop_names rΓ)
+          (fold_right
+            (fun '(x, fn_call, x', md', xty, u) ty =>
+              tProd (nNamed x') xty
+              (match md' with
+               | Some d' => tProd (nNamed d') (mkApps Delay [u; tVar x']) ty
+               | None => ty
+               end))
+            (fn (mkApps <%@eq%> [mkApps univD [t_univ]; mkApps delayD [t_univ; tVar e; tVar d]; r.(rLhs)])
+            (fold_right
+              (fun '(x, fn_call, x', md', xty, u) ty =>
+                match md' with
+                | Some d' =>
+                  let lhs :=
+                    match fn_call with
+                    | Some fn_call => mkApps fn_call [tVar x]
+                    | None => tVar x
+                    end
+                  in
+                  fn (mkApps <%@eq%> [xty; lhs; mkApps delayD [u; tVar x'; tVar d']]) ty
+                | None => ty
+                end)
+              (fn (mkApps <%@eq%> [mkApps univD [t_univ]; tVar e; old_lhs])
+              (fn (mkApps Param [t_univ; tVar C]) (fn (mkApps State [t_univ; tVar C; r.(rRhs)]) (tVar Ans))))
+              extra_vars))
+            extra_vars)))))
+      applicable
+  in
+  let ctx_ty := mkApps frames_t [t_univ; root] in
+  ret (fn (mkApps <%@Topdown%> [rw_univ; t_univ])
+    (tProd (nNamed Ans) type0 
+    (tProd (nNamed C) (mkApps <%erased%> [ctx_ty])
+    (tProd (nNamed C_ok) (mkApps <%@e_ok%> [ctx_ty; tVar C])
+    (tProd (nNamed e) (mkApps univD [t_univ])
+    (tProd (nNamed d) (mkApps Delay [t_univ; tVar e])
+    (tProd (nNamed r) (mkApps Param [t_univ; tVar C]) 
+    (tProd (nNamed s) (mkApps State [t_univ; tVar C; mkApps delayD [t_univ; tVar e; tVar d]])
+    (fold_right fn (fold_right fn (tVar Ans) congruences) applicable)))))))))
+)).
+Defined.
+
+Definition gen_bottomup_ty (t_univ_i : N) : GM term. ltac1:(refine(
+  let n_univs := mfold (fun u n m => insert n u m) empty univ_of_tyname in
+  let! t_tyname := findM'' t_univ_i n_univs "t_univ_i" in
+  let t_univ_i := N.to_nat t_univ_i in
+  let! t_ty := findM' t_tyname graph.(mgTypes) "t_tyname" in
+  let! '(ind, pars) := decompose_ind decls t_ty in
+  let! Ans := gensym "Ans" in
+  let! C := gensym "C" in
+  let! C_ok := gensym "C_ok" in
+  let! e := gensym (abbreviate t_tyname) in
+  let! r := gensym "r" in
+  let! s := gensym "s" in
+  let t_univ := mk_univ t_univ_i in
+  let! constrs := findM' t_tyname graph.(mgConstrs) "t_tyname" in
+  let applicable :=
+    filter
+      (fun r => match r.(rDir) with dBottomup => r.(rHoleU) ==? t_univ_i | dTopdown => false end)
+      rules.(rRules)
+  in
+  let! applicable :=
+    mapM
+      (fun r =>
+        let! localC :=
+          match r.(rC) with
+          | tVar C => ret C
+          | t => raise ("gen_extra_vars_ty: expected tVar, got: " +++ string_of_term t)
+          end
+        in
+        let rΓ := filter (fun '(x, decl) => negb (x ==? localC)) r.(rΓ) in
+        let σ := sing localC C in
+        let rΓ := map (on_snd (map_decl (rename σ))) rΓ in
+        let! header :=
+          gen_case_tree ind_info [(tVar e, r.(rLhs))] type0 
+            (mkApps <%Active%> [quote_string r.(rName)])
+            <%Impossible%>
+        in
+        ret (fn (mkApps <%InspectCaseRule%> [quote_string r.(rName)]) (fn header
+          (it_mkProd_or_LetIn (drop_names rΓ)
+          (fn (mkApps <%@eq%> [mkApps univD [t_univ]; tVar e; r.(rLhs)])
+          (fn (mkApps State [t_univ; tVar C; r.(rRhs)]) (tVar Ans)))))))
+      applicable
+  in
+  let ctx_ty := mkApps frames_t [t_univ; root] in
+  ret (fn (mkApps <%@Bottomup%> [rw_univ; t_univ])
+    (tProd (nNamed Ans) type0 
+    (tProd (nNamed C) (mkApps <%erased%> [ctx_ty])
+    (tProd (nNamed C_ok) (mkApps <%@e_ok%> [ctx_ty; tVar C])
+    (tProd (nNamed e) (mkApps univD [t_univ])
+    (tProd (nNamed r) (mkApps Param [t_univ; tVar C]) 
+    (tProd (nNamed s) (mkApps State [t_univ; tVar C; tVar e])
+    (fold_right fn (fn (fn <%Fallback%> (tVar Ans)) (tVar Ans)) (rev applicable)))))))))
+)).
+Defined.
+
+Definition gen_inspect_tys : GM (list term × list term). ltac1:(refine(
+  let! ns :=
+    foldrM
+      (fun '(ty, _) ns =>
+        if member ty graph.(mgAtoms) then ret ns else
+        let! n := findM ty univ_of_tyname in
+        ret (n :: ns))
+      [] (list_of_map graph.(mgTypes))
+  in
+  let! tynames :=
+    foldrM
+      (fun '(ty, _) ns =>
+        if member ty graph.(mgAtoms) then ret ns else
+        ret (ty :: ns))
+      [] (list_of_map graph.(mgTypes))
+  in
+  let! topdown_named := mapM gen_topdown_ty ns in
+  let! bottomup_named := mapM gen_bottomup_ty ns in
+  let! topdown_tys := mapM (indices_of []) topdown_named in
+  let! bottomup_tys := mapM (indices_of []) bottomup_named in
+  ret (topdown_tys, bottomup_tys)
+)).
+Defined.
+
+End GoalGeneration.
+
+(* ---------- Toplevel tactic to generate the above ---------- *)
+
+Section GoalGeneration.
+
+Context (aux : aux_data_t) (rules : rules_t) (fueled metric D I_D R I_R S I_S delayD : term).
+
+Definition gen_all : GM (RwObligations term). ltac1:(refine(
+  let! extra_vars := gen_extra_vars_tys aux rules D I_D R I_R S I_S delayD in
+  let! run_rules := gen_run_rule_tys rules fueled metric R I_R S I_S in
+  let! constr_delays := gen_constr_delay_tys aux rules D I_D delayD in
+  let! smart_constrs := gen_smart_constr_tys aux rules fueled metric R I_R S I_S in
+  let! '(topdowns, bottomups) := gen_inspect_tys aux rules D I_D R I_R S I_S delayD in
+  ret (mk_obs extra_vars run_rules constr_delays smart_constrs topdowns bottomups)
+)).
+Defined.
+
+(* Danger: running [unquote_all] generates universe constraints between the things inside 
+   each typed_term and pretty common monomorphic types like [list], [pair], [option], etc.
+   It's safer to unquote each term in obs with ltac. *)
+Definition unquote_all (obs : RwObligations term)
+ : TemplateMonad (RwObligations typed_term). ltac1:(refine(
+  let '(mk_obs extra_vars run_rules constr_delays smart_constrs topdowns bottomups) :=
+    obs
+  in
+  extra_vars <- monad_map tmUnquote extra_vars ;;
+  run_rules <- monad_map tmUnquote run_rules ;;
+  constr_delays <- monad_map tmUnquote constr_delays ;;
+  smart_constrs <- monad_map tmUnquote smart_constrs ;;
+  topdowns <- monad_map tmUnquote topdowns ;;
+  bottomups <- monad_map tmUnquote bottomups ;;
+  ret (mk_obs extra_vars run_rules constr_delays smart_constrs topdowns bottomups)
+)).
+Abort.
+
+End GoalGeneration.
+
+Ltac unquote_and_assert_terms terms k :=
+  lazymatch terms with
+  | [] => k tt
+  | ?t :: ?rest =>
+    run_template_program (tmUnquote t) ltac:(fun t' =>
+    match t' with
+    | {| my_projT2 := ?t'' |} => assert t''; [|unquote_and_assert_terms rest k]
+    end)
+  end.
+
+Ltac unquote_and_assert_obs obs k :=
+  lazymatch obs with
+  | mk_obs ?extra_vars ?run_rules ?constr_delays ?smart_constrs ?topdowns ?bottomups =>
+    unquote_and_assert_terms extra_vars ltac:(fun _ =>
+    unquote_and_assert_terms run_rules ltac:(fun _ =>
+    unquote_and_assert_terms constr_delays ltac:(fun _ =>
+    unquote_and_assert_terms smart_constrs ltac:(fun _ =>
+    unquote_and_assert_terms topdowns ltac:(fun _ =>
+    unquote_and_assert_terms bottomups k)))))
+  end.
+
+Ltac mk_rw_obs k :=
+  lazymatch goal with
+  | |- @rewriter ?U ?HFrame ?HAux ?root ?fueled ?metric ?Rstep ?D ?I_D ?HDelay ?R ?I_R ?S ?I_S _ _ _ =>
+    parse_rel 0 Rstep ltac:(fun rules n =>
+    run_template_program (
+      fueled' <- tmQuote fueled ;;
+      metric' <- tmQuote metric ;;
+      D' <- tmQuote D ;;
+      I_D' <- tmQuote I_D ;;
+      R' <- tmQuote (@R) ;;
+      I_R' <- tmQuote (@I_R) ;;
+      S' <- tmQuote (@S) ;;
+      I_S' <- tmQuote (@I_S) ;;
+      delayD <- tmQuote (@delayD U HFrame D I_D HDelay) ;;
+      ret (fueled', metric', D', I_D', R', I_R', S', I_S', delayD)) ltac:(fun pack =>
+    lazymatch pack with
+    | (?fueled', ?metric', ?D', ?I_D', ?R', ?I_R', ?S', ?I_S', ?delayD) =>
+      runGM n (
+        let! fueled'' := named_of [] fueled' in
+        let! metric'' := named_of [] metric' in
+        let! D'' := named_of [] D' in
+        let! I_D'' := named_of [] I_D' in
+        let! delayD' := named_of [] delayD in
+        let! R'' := named_of [] R' in
+        let! I_R'' := named_of [] I_R' in
+        let! S'' := named_of [] S' in
+        let! I_S'' := named_of [] I_S' in
+        gen_all HAux rules fueled'' metric'' D'' I_D'' R'' I_R'' S'' I_S'' delayD') ltac:(fun qobs n =>
+        unquote_and_assert_obs qobs k)
+    end))
+  end.
+
+Ltac mk_rw' := mk_rw_obs ltac:(fun _ => idtac).
+
+Ltac mk_smart_constr_children Root Rstep I_R I_S C s hasHrel Hrel :=
+  lazymatch goal with
+  | H : SmartConstrCase (frameD ?frame ?hole) -> _ |- _ =>
+    specialize (H (MkSmartConstrCase _));
+    let x := fresh "x" in
+    let s' := fresh "s" in
+    let Hrel' := fresh "Hrel" in
+    unshelve edestruct H as [x s' Hrel'];
+    [(* Siblings *)..|(* n *)|(* e_ok n *)
+    |(* Param *)eapply (@preserve_R _ _ Root _ I_R _); eassumption
+    |(* State *)eapply (@preserve_S_dn _ _ Root _ I_S _); cbn; eassumption
+    |(* equation about n *)
+    |];
+    [(* Siblings *)..|(* n *)refine (e_map (fun C => _) C)|(* e_ok n *)|(* equation about n *)|];
+    [(* n *)|(* e_ok (e_map ..) *)apply e_map_ok; assumption
+    |(* equation about n *)unerase; reflexivity
+    |];
+    clear H s;
+    apply (@preserve_S_up _ _ Root _ I_S _) in s'; [|assumption]; cbn in s';
+    lazymatch hasHrel with
+    | false => mk_smart_constr_children Root Rstep I_R I_S C s' true Hrel'
+    | true =>
+      let Hrel'' := fresh "Hrel" in
+      match goal with |- result _ _ ?C ?e1 =>
+      match type of s' with State _ C ?e2 =>
+      match type of C with erased ?T =>
+        assert (Hrel'' : «e_map (fun (C : T) => clos_refl_trans _ Rstep (C⟦e1⟧) (C⟦e2⟧)) C»);
+        [unerase; eapply rt_trans; [exact Hrel|exact Hrel']|];
+        clear Hrel Hrel'
+      end end end;
+      mk_smart_constr_children Root Rstep I_R I_S C s' true Hrel''
+    end
+  | _ =>
+    lazymatch hasHrel with
+    | false => econstructor; [exact s|unerase; apply rt_refl]
+    | true => econstructor; [exact s|exact Hrel]
+    end
+  end.
+Ltac mk_smart_constr :=
+   clear;
+   let fuel := fresh "fuel" in
+   let C := fresh "C" in
+   let emetric := fresh "emetric" in
+   let Hemetric_ok := fresh "Hemetric_ok" in
+   let Hemetric := fresh "Hemetric" in
+   let r := fresh "r" in
+   let s := fresh "s" in
+   intros _ fuel C; intros;
+   lazymatch goal with
+   | |- @rw_for ?U ?HFrame ?Root ?fueled ?metric ?Rstep ?R ?I_R ?S ?I_S ?fuel _ _ _ =>
+     unfold rw_for in *;
+     intros emetric Hemetric_ok r s Hemetric;
+     mk_smart_constr_children Root Rstep I_R I_S C s false None
+   end.
+
+Definition tm_get_constr (s : string) : TemplateMonad typed_term :=
+  ref <- tmAbout s ;;
+  match ref with
+  | Some (ConstructRef ind n) => tmUnquote (tConstruct ind n [])
+  | _ => tmFail ("tm_get_constr: not a constructor: " +++ s)
+  end.
+
+Ltac mk_run_rule :=
+  lazymatch goal with
+  | |- RunRule ?rule -> _ =>
+    clear;
+    let fuel := fresh "fuel" in
+    let C := fresh "C" in
+    intros _ fuel C; intros;
+    let r := fresh "r" in
+    let s := fresh "s" in
+    let Hnext := fresh "Hnext" in
+    let emetric := fresh "emetric" in
+    let Hemetric_ok := fresh "Hemetric_ok" in
+    let Hemetric := fresh "Hemetrick" in
+    lazymatch goal with H1 : _, H2 : _, H3 : _ |- _ => revert H1 H2 H3 end;
+    unfold rw_for; intros r s Hnext emetric Hemetric_ok _ _ Hemetric;
+    let x' := fresh "x'" in
+    let s' := fresh "s'" in
+    let Hrel := fresh "Hrel" in
+    unshelve edestruct Hnext as [x' s' Hrel];
+    [(* n *)refine (e_map (fun C => _) C)|(* e_ok n *)
+    |(* Param *)exact r|(* State *)exact s
+    |(* equation about metric *)unerase; reflexivity|];
+    [(* e_ok (e_map (fun C => new metric) C) *)apply e_map_ok; assumption|];
+    econstructor; [exact s'|];
+    unerase; eapply rt_trans; [eapply rt_step|exact Hrel];
+    run_template_program (tm_get_constr rule) ltac:(fun ctor =>
+    match ctor with
+    | {| my_projT2 := ?ctor' |} =>
+      eapply ctor';
+      lazymatch goal with
+      | _ => eassumption
+      end
+    end)
+  end.
+
+(* Used by mk_topdown *)
+Ltac strip_one_match :=
+  lazymatch goal with
+  | H : InspectCaseRule _ -> match ?e with _ => _ end -> _ |- _ =>
+    let Heqn := fresh "Heqn" in
+    destruct e eqn:Heqn;
+    repeat lazymatch goal with
+    | H : InspectCaseRule _ -> Impossible -> _ |- _ => clear H
+    | H : InspectCaseCongruence _ -> Impossible -> _ |- _ => clear H
+    end
+  | H : InspectCaseCongruence _ -> match ?e with _ => _ end -> _ |- _ =>
+    let Heqn := fresh "Heqn" in
+    destruct e eqn:Heqn;
+    repeat lazymatch goal with
+    | H : InspectCaseRule _ -> Impossible -> _ |- _ => clear H
+    | H : InspectCaseCongruence _ -> Impossible -> _ |- _ => clear H
+    end
+  end.
+Ltac mk_topdown_congruence :=
+  lazymatch goal with
+  | H : InspectCaseRule _ -> Active _ -> _ |- _ => fail
+  | H : InspectCaseCongruence _ -> Congruence ?constr -> _, Hdelay : ConstrDelay ?constr -> _ |- _ =>
+    eapply (Hdelay (MkConstrDelay constr)); intros;
+    eapply (H (MkInspectCaseCongruence constr) (MkCongruence constr));
+    solve [eassumption|reflexivity]
+  end.
+Ltac mk_topdown_active r s :=
+  lazymatch goal with
+  | H : InspectCaseRule _ -> Active ?rule -> _, Hextras : ExtraVars ?rule -> _ |- _ =>
+    eapply (Hextras (MkExtraVars rule));
+    [(* Find all the misc. arguments by unification *) eassumption ..
+    |(* Success continuation: add rhs vars + assumptions above the line *)
+     intros _; intros
+    |(* Failure continuation: forget everything about the rule we just applied *)
+     intros _; clear Hextras H];
+    [(* Success: switch to new env + state and apply the proper rule *)
+     lazymatch goal with
+     | H1 : _ , H2 : _ |- _ =>
+       let r_old := fresh "r_old" in
+       let s_old := fresh "s_old" in
+       rename r into r_old, s into s_old, H1 into r, H2 into s;
+       eapply (H (MkInspectCaseRule rule) (MkActive rule)); [..|reflexivity|exact r|exact s];
+       eassumption
+     end
+    |(* Failure: try to apply other rules *)
+      mk_topdown_active r s]
+  | _ => mk_topdown_congruence
+  end.
+Ltac mk_topdown :=
+  repeat lazymatch goal with
+  | H : Topdown -> _ |- _ => clear H
+  | H : SmartConstr _ -> _ |- _ => clear H
+  end;
+  let d := fresh "d" in
+  let R := fresh "R" in
+  let C := fresh "C" in
+  let e := fresh "e" in
+  let r := fresh "r" in
+  let s := fresh "s" in
+  intros _ R C e d r s; intros;
+  repeat strip_one_match;
+  mk_topdown_active r s.
+
+Ltac mk_bottomup_fallback :=
+  lazymatch goal with
+  | H : InspectCaseRule _ -> Active _ -> _ |- _ => fail
+  | H : Fallback -> _ |- _ => exact (H MkFallback)
+  end.
+Ltac mk_bottomup_active :=
+  lazymatch goal with
+  | H : InspectCaseRule _ -> Active ?rule -> _, Hextras : ExtraVars ?rule -> _ |- _ =>
+    eapply (Hextras (MkExtraVars rule));
+    [eassumption..|intros _; intros|intros _; clear Hextras H];
+    [eapply (H (MkInspectCaseRule rule) (MkActive rule)); eauto
+    |mk_bottomup_active]
+  | _ => mk_bottomup_fallback
+  end.
+Ltac mk_bottomup :=
+  repeat lazymatch goal with
+  | H : Topdown -> _ |- _ => clear H
+  | H : Bottomup -> _ |- _ => clear H
+  | H : SmartConstr _ -> _ |- _ => clear H
+  end;
+  let R := fresh "R" in
+  let C := fresh "C" in
+  let e := fresh "e" in
+  let r := fresh "r" in
+  let s := fresh "s" in
+  intros _ R C e r s; intros;
+  repeat strip_one_match;
+  mk_bottomup_active.
+
+Require Import Coq.PArith.BinPos Lia.
+
+Ltac try_find_constr e k_constr k_atom :=
+  lazymatch goal with
+  | H : SmartConstr e -> _ |- _ => k_constr e H
+  | _ =>
+    lazymatch e with
+    | ?e' _ => try_find_constr e' k_constr k_atom
+    | _ => k_atom e
+    end
+  end.
+Ltac next_action e k_rec k_constr k_atom :=
+  lazymatch e with
+  | Rec ?e' => k_rec e'
+  | _ => try_find_constr e k_constr k_atom
+  end.
+
+Lemma nonempty_nonzero (fuel : Rewriting.Fuel true) : is_empty true fuel = false -> (fuel > 1)%positive.
+Proof. unfold is_empty; destruct fuel; try ltac1:(lia); now inversion 1. Qed.
+
+Inductive MetricDecreasing := MkMetricDecreasing.
+Ltac apply_recur recur fuel fueled metric Hempty :=
+  match fueled with
+  | true =>
+    specialize recur with (fuel := Pos.pred fuel);
+    specialize (recur (erase (Pos.to_nat (Pos.pred fuel))) _);
+    apply recur; try assumption;
+    repeat lazymatch goal with
+    | |- e_lt _ _ =>
+      unfold e_lt; unerase; subst; cbn;
+      apply nonempty_nonzero in Hempty; lia
+    | |- e_ok (e_map _ _) => apply e_map_ok
+    | |- e_ok _ => assumption
+    | |- «_» => unerase; reflexivity
+    end
+  | false =>
+    specialize recur with (fuel := fuel); unfold Rec; rewrite ?e_map_fuse;
+    lazymatch goal with
+    | |- result _ _ ?C' (@delayD ?univ ?HFrame ?D ?I_D ?HD ?A ?e ?d') =>
+      lazymatch C' with
+      | e_map ?f ?C'' =>
+        specialize recur with
+          (C := C')
+          (y := e_map (fun C => metric _ (f C) (@delayD univ HFrame D I_D HD A e d')) C'')
+          (d := d')
+      | _ =>
+        specialize recur with
+          (C := C')
+          (y := e_map (fun C => metric _ C (@delayD univ HFrame D I_D HD A e d')) C')
+          (d := d')
+      end;
+      eapply recur;
+      repeat lazymatch goal with
+      | |- Param _ _ => assumption
+      | |- State _ _ _ => assumption
+      | |- e_ok (e_map _ _) => apply e_map_ok
+      | |- e_ok _ => assumption
+      | |- «_» => unerase; unfold run_metric; reflexivity
+      | |- e_lt _ _ =>
+        unfold e_lt; unerase;
+        lazymatch goal with
+        | |- (_ < ?x)%nat => subst x; unfold run_metric
+        end;
+        let dummy := fresh "dummy" in
+        pose (dummy := MkMetricDecreasing); clearbody dummy; revert dummy
+      end
+    end
+  end.
+
+Ltac mk_edit_rhs recur fuel fueled metric Hempty :=
+  let rec go _ :=
+    lazymatch goal with
+    | |- @rw_for _ _ _ _ _ _ _ _ _ _ _ _ _ ?e =>
+      next_action e
+        (* Recursive calls: *)
+        ltac:(fun e' =>
+          (* Rewrite any call pending on the current subterm in terms of delayed computation *)
+          lazymatch goal with
+          | H : e' = delayD ?d |- _ =>
+            rewrite H;
+            let emetric := fresh "emetric" in
+            let Hemetric_ok := fresh "Hemetric_ok" in
+            let r := fresh "r" in
+            let s := fresh "s" in
+            let Hemetric := fresh "Hemetric" in
+            intros emetric Hemetric_ok r s Hemetric;
+            apply_recur recur fuel fueled metric Hempty
+          end)
+        (* Constructor nodes: apply the smart constructor... *)
+        ltac:(fun constr Hconstr =>
+          apply (Hconstr (MkSmartConstr constr) fuel);
+          repeat match goal with
+          | |- e_ok (e_map _ _) => apply e_map_ok
+          | |- e_ok _ => assumption
+          end;
+          (* ...and recursively expand each child *)
+          intros _; intros; go tt)
+        (* Atoms: just return the atom *)
+        ltac:(fun e => unfold rw_for; intros; econstructor; [|unerase; apply rt_refl]; assumption)
+    end
+  in go tt.
+
+Inductive Sentinel := MkSentinel. (* used by mk_rewriter *)
+Ltac mk_rewriter :=
+  lazymatch goal with
+  | |- @rewriter ?univ ?HFrame _ ?Root ?fueled ?metric ?Rstep ?D ?I_D ?HD ?R ?I_R ?S ?I_S _ _ _ =>
+    unfold rewriter, rewriter';
+    lazymatch goal with
+    | |- forall (_ : Rewriting.Fuel _), _ =>
+      (* Pull the erased nat and its e_ok proof to the front *)
+      let sentinel := fresh "sentinel" in
+      let emetric := fresh "emetric" in
+      let Hemetric_ok := fresh "Hemetric_ok" in
+      pose (sentinel := MkSentinel : Sentinel);
+      clearbody sentinel;
+      intros; unfold rw_for; intros emetric Hemetric_ok;
+      repeat progress lazymatch goal with
+      | H : ?T, emetric : _, Hemetric_ok : _ |- _ =>
+        lazymatch T with
+        | Sentinel => idtac
+        | _ => revert H
+        end
+      end;
+      (* Now apply the fixpoint combinator *)
+      pattern emetric; revert emetric Hemetric_ok;
+      let recur := fresh "recur" in
+      let fuel := fresh "fuel" in
+      let A := fresh "A" in
+      apply FixEN; intros emetric Hemetric_ok recur fuel A;
+      (* Check if fuel-based and fuel empty, and return e unchanged if so *)
+      let Hempty := fresh "Hempty" in
+      match fueled with
+      | true =>
+        destruct (is_empty fueled fuel) eqn:Hempty;
+        [econstructor; [|unerase; apply rt_refl]; assumption|]
+      | false => idtac
+      end;
+      (* Case split on type tag *)
+      destruct A;
+      lazymatch goal with
+      (* Nonatomic children: apply topdown rules and then bottomup rules *)
+      | Htopdown : Topdown ?hole -> _ |- forall _ : erased (frames_t ?hole _), _ =>
+        let C := fresh "C" in
+        let C_ok := fresh "C_ok" in
+        let e := fresh "e" in
+        let d := fresh "d" in
+        let r := fresh "r" in
+        let s := fresh "s" in
+        let Hemetric := fresh "Hemetric" in
+        intros C C_ok e d r s Hemetric;
+        apply (@res_chain univ HFrame Root Rstep S I_S _ C C_ok);
+        [ apply (Htopdown (MkTopdown hole) _ C C_ok e d r s);
+          lazymatch goal with
+          (* Rule applications *)
+          | Hrun : RunRule ?rule -> _ |- InspectCaseRule ?rule -> _ =>
+            intros _ _; intros;
+            lazymatch goal with He : delayD d = _ |- _ => rewrite He in * end;
+            let r'' := fresh "r" in
+            let s'' := fresh "s" in
+            lazymatch goal with H1 : _, H2 : _ |- _ => rename H1 into r'', H2 into s'' end;
+            eapply (Hrun (MkRunRule rule) fuel);
+            lazymatch goal with
+            | |- Param _ _ => eassumption
+            | |- State _ _ _ => eassumption
+            | |- «_» => eassumption
+            | |- e_ok _ => eassumption
+            | _ => idtac
+            end;
+            [try eassumption..|mk_edit_rhs recur fuel fueled metric Hempty]
+          (* Congruence cases *)
+          | Hconstr : SmartConstr ?constr -> _ |- InspectCaseCongruence ?constr -> _ =>
+            intros _ _; intros;
+            lazymatch goal with Hdelay : delayD d = _ |- _ => rewrite Hdelay in * end;
+            let r' := fresh "r" in
+            let s' := fresh "s" in
+            let Hemetric' := fresh "Hemetric" in
+            let r_t := type of r in assert (r' : r_t) by exact r;
+            let s_t := type of s in assert (s' : s_t) by exact s;
+            let Hemetric_t := type of Hemetric in assert (Hemetric' : Hemetric_t) by exact Hemetric;
+            revert r' s' Hemetric';
+            unfold rw_for in Hconstr;
+            apply (Hconstr (MkSmartConstr _) fuel C C_ok); try exact Hemetric_ok;
+            intros _; intros;
+            lazymatch goal with
+            (* If child is nonatomic (has call to delayD), recur *)
+            | |- result _ _ _ (delayD _) =>
+              apply_recur recur fuel fueled metric Hempty
+            (* Otherwise, just return it *)
+            | |- result _ _ _ _ => econstructor; [|unerase; apply rt_refl]; assumption
+            end
+          end
+        | lazymatch goal with
+          | Hbottomup : Bottomup hole -> _ |- _ =>
+            clear emetric Hemetric_ok recur d e s Hemetric; intros e s;
+            apply (Hbottomup (MkBottomup hole) _ C C_ok e r s);
+            lazymatch goal with
+            (* Rule applications *)
+            | Hrun : RunRule ?rule -> _ |- InspectCaseRule ?rule -> _ =>
+              intros _ _; intros;
+              lazymatch goal with He : e = _ |- _ => rewrite He in * end;
+              (* Run the rule... *)
+              let s'' := fresh "s" in
+              lazymatch goal with H : _ |- _ => rename H into s'' end;
+              unshelve eapply (Hrun (MkRunRule rule) fuel);
+              try lazymatch goal with
+              | |- erased nat => refine (erase _)
+              | |- State _ _ _ => exact s''
+              | |- «_» => unerase; unfold run_metric; reflexivity
+              end;
+              try lazymatch goal with
+              | |- e_ok (erase _) => apply erase_ok
+              | _ => assumption
+              end;
+              (* ...and then just return the modified tree *)
+              unfold rw_for; intros; econstructor; [|unerase; apply rt_refl]; assumption
+            (* Fallback (just return the child) *)
+            | |- Fallback -> _ =>
+              intros _; econstructor; [|unerase; apply rt_refl]; assumption
+            end
+          end
+        ]
+      (* Atomic children: Just run the delayed computation *)
+      | |- forall _ : erased (frames_t ?hole _), _ =>
+        let C := fresh "C" in
+        let C_ok := fresh "C_ok" in
+        let e := fresh "e" in
+        let d := fresh "d" in
+        intros C C_ok e d; intros;
+        econstructor; [|unerase; apply rt_refl]; assumption
+      end
+    end
+  end.
+
+(* Like mk_rw', but apply the default automation and only leave behind nontrivial goals *)
+Ltac mk_rw :=
+  mk_rw';
+  lazymatch goal with
+  | |- SmartConstr _ -> _ => mk_smart_constr
+  | |- RunRule _ -> _ => mk_run_rule
+  | |- Topdown _ -> _ => mk_topdown
+  | |- Bottomup _ -> _ => mk_bottomup
+  | _ => idtac
+  end;
+  [..|mk_rewriter].
+
+Ltac mk_easy_delay :=
+  try lazymatch goal with
+  | |- ConstrDelay _ -> _ =>
+    clear; simpl; intros; lazymatch goal with H : forall _, _ |- _ => eapply H; try reflexivity; eauto end
+  end.
+
+Ltac cond_failure :=
+  lazymatch goal with
+  | H : Failure ?rule -> ?R |- ?R =>
+    apply (H (MkFailure rule))
+  end.
+
+Ltac cond_success name :=
+  lazymatch goal with
+  | Hs : Success ?rule -> _, Hf : Failure ?rule -> _ |- ?R =>
+    specialize (Hs (MkSuccess rule)); clear Hf; rename Hs into name
+  end.
+

--- a/theories/L6_PCPS/PrototypeGenFrame.v
+++ b/theories/L6_PCPS/PrototypeGenFrame.v
@@ -1,0 +1,736 @@
+Require Import Coq.Strings.Ascii Coq.Strings.String.
+Infix "+++" := append (at level 60, right associativity).
+
+Require Import Coq.Lists.List.
+Import ListNotations.
+
+From MetaCoq Require Import Template.All.
+Import MonadNotation.
+Module TM := MetaCoq.Template.monad_utils.
+
+From ExtLib.Core Require Import RelDec.
+From ExtLib.Data Require Import Nat List Option Pair String.
+From ExtLib.Structures Require Import Monoid Functor Applicative Monads Traversable.
+From ExtLib.Data.Monads Require Import IdentityMonad EitherMonad StateMonad.
+
+Require Import Coq.NArith.BinNat.
+Local Open Scope N_scope.
+
+Require Import Coq.Relations.Relations.
+
+Require Import Ltac2.Ltac2.
+Import Ltac2.Notations.
+Set Default Proof Mode "Ltac2".
+
+(* Set Universe Polymorphism. *)
+
+Require Export CertiCoq.L6.Frame.
+
+Instance Monad_TemplateMonad : Monad TemplateMonad := {
+  ret _ := TM.ret;
+  bind _ _ := TM.bind }.
+
+Notation "'let!' x ':=' c1 'in' c2" := (@bind _ _ _ _ c1 (fun x => c2))
+  (at level 61, c1 at next level, right associativity).
+Notation "'let!' ' p ':=' c1 'in' c2" :=
+  (@bind _ _ _ _ c1 (fun x => match x with p => c2 end))
+  (at level 61, p pattern, c1 at next level, right associativity).
+Infix "<$>" := fmap (at level 52, left associativity).
+Infix "<*>" := ap (at level 52, left associativity).
+
+Section Helpers.
+
+Context {M : Type -> Type} {A B : Type} `{Monad M}.
+
+Definition mapM (f : A -> M B) : list A -> M (list B) :=
+  fix go xs :=
+    match xs with
+    | [] => pure []
+    | x :: xs => pure cons <*> f x <*> go xs
+    end.
+
+Definition mapi' (f : nat -> A -> B) : list A -> list B :=
+  (fix go n xs :=
+    match xs with
+    | [] => []
+    | x :: xs => f n x :: go (S n) xs
+    end) O.
+
+Definition mapiM (f : N -> A -> M B) : list A -> M (list B) :=
+  (fix go n xs :=
+    match xs with
+    | [] => pure []
+    | x :: xs => pure cons <*> f n x <*> go (1 + n) xs
+    end) 0.
+
+Definition mapiM_nat (f : nat -> A -> M B) : list A -> M (list B) :=
+  (fix go n xs :=
+    match xs with
+    | [] => pure []
+    | x :: xs => pure cons <*> f n x <*> go (S n) xs
+    end) O.
+
+Definition foldrM (f : A -> B -> M B) (e : B) (xs : list A) : M B :=
+  fold_right (fun x m => let! y := m in f x y) (ret e) xs.
+
+Definition foldlM (f : B -> A -> M B) (x : B) : list A -> M B :=
+  let fix go acc xs :=
+    match xs with
+    | [] => ret acc
+    | x :: xs =>
+      let! acc := f acc x in
+      go acc xs
+    end
+  in go x.
+
+Definition foldri {A B} (f : N -> A -> B -> B) (g : N -> B) : list A -> B :=
+  let fix go n xs :=
+    match xs with
+    | [] => g n
+    | x :: xs => f n x (go (1 + n) xs)
+    end
+  in go 0.
+
+Definition foldri_nat {A B} (f : nat -> A -> B -> B) (g : nat -> B) : list A -> B :=
+  let fix go n xs :=
+    match xs with
+    | [] => g n
+    | x :: xs => f n x (go (S n) xs)
+    end
+  in go O.
+
+Definition foldli (f : N -> B -> A -> B) (x : B) : list A -> B :=
+  let fix go n acc xs :=
+    match xs with
+    | [] => acc
+    | x :: xs =>
+      let acc := f n acc x in
+      go (1 + n) acc xs
+    end
+  in go 0 x.
+
+Definition foldriM (f : N -> A -> B -> M B) (x : B) : list A -> M B :=
+  let fix go n xs :=
+    match xs with
+    | [] => ret x
+    | x :: xs => let! y := go (1 + n) xs in f n x y
+    end
+  in go 0.
+
+Definition foldriM_nat (f : nat -> A -> B -> M B) (x : B) : list A -> M B :=
+  let fix go n xs :=
+    match xs with
+    | [] => ret x
+    | x :: xs => let! y := go (S n) xs in f n x y
+    end
+  in go O.
+
+Definition foldliM (f : N -> B -> A -> M B) (x : B) : list A -> M B :=
+  let fix go n acc xs :=
+    match xs with
+    | [] => ret acc
+    | x :: xs =>
+      let! acc := f n acc x in
+      go (1 + n) acc xs
+    end
+  in go 0 x.
+
+End Helpers.
+
+(* -------------------- Finite maps -------------------- *)
+
+Notation "'Eq' A" := (RelDec (@eq A)) (at level 1, no associativity).
+Infix "==?" := eq_dec (at level 40, no associativity).
+
+Instance Eq_N : Eq N := {rel_dec := N.eqb}.
+
+Definition Map A B := list (A * B).
+Definition Set' A := Map A unit.
+
+Definition empty {A B} : Map A B := [].
+
+Definition sing {A B} k v : Map A B := [(k, v)].
+
+Definition size {A B} (m : Map A B) : nat := #|m|.
+
+Definition insert {A B} k v m : Map A B := (k, v) :: m.
+
+Definition delete {A B} `{Eq A} k : Map A B -> Map A B :=
+ filter (fun '(k', _) => negb (k ==? k')).
+
+Fixpoint find {A B} `{Eq A} k m : option B :=
+  match m with
+  | [] => None
+  | (k', v) :: m => if k ==? k' then Some v else find k m
+  end.
+
+Fixpoint find_d {A B} `{Eq A} k d m : B :=
+  match m with
+  | [] => d
+  | (k', v) :: m => if k ==? k' then v else find_d k d m
+  end.
+
+Definition find_exc {M E A B} `{Eq A} `{Monad M} `{MonadExc E M} k m e : M B :=
+  match find k m with
+  | Some v => ret v
+  | None => raise e
+  end.
+
+Definition update {A B} `{Eq A} k (f : B -> B) d m : Map A B :=
+  insert k (f (find_d k d m)) m.
+
+Definition list_of_map {A B} : Map A B -> list (A * B) := id.
+
+Definition map_of_list {A B} : list (A * B) -> Map A B := id.
+Definition set_of_list {A} (xs : list A) : Set' A := map_of_list (map (fun x => (x, tt)) xs).
+Definition list_of_set {A} : Set' A -> list A := map fst.
+Definition set_of_option {A} (x : option A) : Set' A :=
+  match x with
+  | Some x => sing x tt
+  | None => empty
+  end.
+
+Definition map_of_ilist {A} : list A -> Map N A :=
+  let fix go n xs :=
+    match xs with
+    | [] => []
+    | x :: xs => (n, x) :: go (1 + n) xs
+    end
+  in go 0.
+
+Definition subset {A B} `{Eq A} `{Eq B} (m1 m2 : Map A B) : bool :=
+  forallb
+    (fun '(k1, v1) =>
+       existsb
+         (fun '(k2, v2) =>
+            if k1 ==? k2
+            then v1 ==? v2
+            else false)
+         m2)
+    m1.
+
+Definition mmap {A B C} (f : B -> C) : Map A B -> Map A C :=
+  fix go m :=
+    match m with
+    | [] => []
+    | (k, x) :: m => (k, f x) :: go m
+    end.
+
+Definition mkmap {A B C} (f : A -> B -> C) : Map A B -> Map A C :=
+  fix go m :=
+    match m with
+    | [] => []
+    | (k, x) :: m => (k, f k x) :: go m
+    end.
+
+Definition mfold {A B C} (f : A -> B -> C -> C) (e : C) : Map A B -> C :=
+  fix go m :=
+    match m with
+    | [] => e
+    | (k, x) :: m => f k x (go m)
+    end.
+
+Definition mfoldM {M A B C} `{Monad M} (f : A -> B -> C -> M C) (e : C) : Map A B -> M C :=
+  fix go m :=
+    match m with
+    | [] => ret e
+    | (k, x) :: m => let! r := go m in f k x r
+    end.
+
+Definition mmapM {M A B C} `{Monad M} (f : B -> M C) : Map A B -> M (Map A C) :=
+  fix go m :=
+    match m with
+    | [] => ret []
+    | (k, x) :: m => cons <$> (pair k <$> f x) <*> go m
+    end.
+
+Definition mchoose {A B} (m : Map A B) : option (A * B) :=
+  match m with
+  | [] => None
+  | kv :: _ => Some kv
+  end.
+
+Definition member {A B} `{Eq A} k (m : Map A B) : bool := if find k m then true else false.
+
+Definition intersect {A B C} `{Eq A} (m1 : Map A B) (m2 : Map A C) : Map A B :=
+  filter (fun '(x, _) => if find x m2 then true else false) m1.
+(* Definition union {A B} (m1 m2 : Map A B) := m1 ++ m2. *)
+Definition union {A B} `{Eq A} (m1 m2 : Map A B) := m1 ++ filter (fun '(x, _) => if find x m1 then false else true) m2.
+Infix "∪" := union (at level 50, left associativity).
+Infix "∩" := intersect (at level 50, left associativity).
+
+Definition minus {A B C} `{Eq A} (m1 : Map A B) (m2 : Map A C) : Map A B :=
+  filter (fun '(x, _) => if find x m2 then false else true) m1.
+Infix "\" := minus (at level 50, left associativity).
+
+Definition union_all {A B} `{Eq A} : list (Map A B) -> Map A B := fold_right union empty.
+
+Definition intersect_by {A B C} `{Eq A} (f : A -> B -> B -> option C) (m1 m2 : Map A B) : Map A C :=
+  fold_right
+   (fun '(k, v1) acc =>
+      match find k m2 with
+      | Some v2 => match f k v1 v2 with Some c => (k, c) :: acc | None => acc end
+      | None => acc
+      end)
+   [] m1.
+
+(* -------------------- Context generation -------------------- *)
+
+(* Reverse hex *)
+Fixpoint string_of_positive n :=
+  match n with
+  | xH => "1"
+  | xO xH => "2"
+  | xI xH => "3"
+  | xO (xO xH) => "4"
+  | xI (xO xH) => "5"
+  | xO (xI xH) => "6"
+  | xI (xI xH) => "7"
+  | xO (xO (xO xH)) => "8"
+  | xI (xO (xO xH)) => "9"
+  | xO (xI (xO xH)) => "A"
+  | xI (xI (xO xH)) => "B"
+  | xO (xO (xI xH)) => "C"
+  | xI (xO (xI xH)) => "D"
+  | xO (xI (xI xH)) => "E"
+  | xI (xI (xI xH)) => "F"
+  | xO (xO (xO (xO n))) => String "0" (string_of_positive n)
+  | xI (xO (xO (xO n))) => String "1" (string_of_positive n)
+  | xO (xI (xO (xO n))) => String "2" (string_of_positive n)
+  | xI (xI (xO (xO n))) => String "3" (string_of_positive n)
+  | xO (xO (xI (xO n))) => String "4" (string_of_positive n)
+  | xI (xO (xI (xO n))) => String "5" (string_of_positive n)
+  | xO (xI (xI (xO n))) => String "6" (string_of_positive n)
+  | xI (xI (xI (xO n))) => String "7" (string_of_positive n)
+  | xO (xO (xO (xI n))) => String "8" (string_of_positive n)
+  | xI (xO (xO (xI n))) => String "9" (string_of_positive n)
+  | xO (xI (xO (xI n))) => String "A" (string_of_positive n)
+  | xI (xI (xO (xI n))) => String "B" (string_of_positive n)
+  | xO (xO (xI (xI n))) => String "C" (string_of_positive n)
+  | xI (xO (xI (xI n))) => String "D" (string_of_positive n)
+  | xO (xI (xI (xI n))) => String "E" (string_of_positive n)
+  | xI (xI (xI (xI n))) => String "F" (string_of_positive n)
+  end.
+Definition string_of_N n :=
+  match n with
+  | N0 => "0"
+  | Npos n => string_of_positive n
+  end.
+Compute (string_of_N 100).
+Compute (string_of_N 200).
+Compute (string_of_N 350).
+
+Notation "'GM'" := (stateT N (sum string)).
+
+Definition fresh (prefix : string) : GM string :=
+  let! n := get in
+  let! _ := modify (fun x => 1 + x) in
+  ret (prefix +++ string_of_N n).
+
+Definition runGM {A} (m : GM A) : TemplateMonad A :=
+  m <- tmEval cbv m ;; (* Necessary: if removed, evaluation takes forever *)
+  match runStateT m 0 with
+  | inl e => tmFail ("runGM: " +++ e)
+  | inr (x, _) => TM.ret x
+  end.
+
+Definition runGM' {A} (n : N) (m : GM A) : string + (A × N) :=
+  runStateT m n.
+
+Definition findM {A} (k : string) (m : Map string A) : GM A :=
+  match find k m with
+  | Some v => ret v
+  | None => raise ("findM: " +++ k)
+  end.
+
+Definition findM' {A} (k : string) (m : Map string A) (s : string) : GM A :=
+  match find k m with
+  | Some v => ret v
+  | None => raise ("findM': " +++ s +++ ": " +++ k)
+  end.
+
+Definition findM'' {A B} `{Eq A} (k : A) (m : Map A B) (s : string) : GM B :=
+  match find k m with
+  | Some v => ret v
+  | None => raise ("findM'': " +++ s)
+  end.
+
+Definition nth_errorN {A} (xs : list A) (n : N) : option A :=
+  let fix go n xs :=
+    match n, xs with
+    | _, [] => None
+    | N0, x :: _ => Some x
+    | n, _ :: xs => go (n - 1) xs
+    end
+  in go 0 xs.
+
+Definition nthM {A} (n : N) (xs : list A) : GM A :=
+  match nth_errorN xs n with
+  | Some v => ret v
+  | None => raise ("nthM: " +++ string_of_N n)
+  end.
+
+Definition nthM_nat {A} (n : nat) (xs : list A) : GM A :=
+  match nth_error xs n with
+  | Some v => ret v
+  | None => raise ("nthM: " +++ nat2string10 n)
+  end.
+
+(* Parse a mutual inductive definition into constructor names + argument types *)
+
+Definition ind_info := Map string ((mutual_inductive_body × list inductive) × nat).
+
+Record mind_graph_t := mk_mg {
+  mgAtoms : Map string term; (* name -> AST e.g. "list_nat" -> tApp {| .. |} {| .. |} *)
+  mgTypes : Map string term; (* name -> AST *)
+  mgConstrs : Map string (list string); (* e.g. "nat" -> ["S"; "O"] *)
+  mgChildren : Map string ((N × list string) × string) }. (* e.g. "cons_nat" -> (1, ["nat"; "list_nat"], "list_nat") *)
+
+Definition is_sep (c : ascii) : bool :=
+  match c with
+  | "." | "#" => true
+  | _ => false
+  end%char.
+
+Fixpoint qualifier (s : string) : string :=
+  let fix go s :=
+    match s with
+    | "" => ("", false)
+    | String c s => 
+      let '(s, qualified) := go s in
+      let qualified := (qualified || is_sep c)%bool in
+      (if qualified then String c s else s, qualified)
+    end
+  in fst (go s).
+
+Fixpoint unqualified (s : string) : string :=
+  let fix go s :=
+    match s with
+    | "" => ("", false)
+    | String c s => 
+      let '(s, qualified) := go s in
+      let qualified := (qualified || is_sep c)%bool in
+      (if qualified then s else String c s, qualified)
+    end
+  in fst (go s).
+
+Definition inductives_of_env (decls : global_env) : ind_info :=
+  fold_right
+    (fun '(kername, decl) m =>
+      match decl with
+      | ConstantDecl _ => m
+      | InductiveDecl mbody =>
+        let qual := qualifier kername in
+        let kernames := mapi (fun i body => (i, qual +++ body.(ind_name))) mbody.(ind_bodies) in
+        let inds := map (fun '(i, kername) => mkInd kername i) kernames in
+        fold_right
+          (fun '(i, kername) m =>
+            insert kername (mbody, inds, i) m)
+          m kernames
+      end)
+    empty
+    decls.
+
+Fixpoint mangle (inds : ind_info) (e : term) : GM string :=
+  match e with
+  | tRel n => raise "mangle: relative binders not allowed"
+  | tApp tycon tys =>
+    let! tycon := mangle inds tycon in
+    foldlM
+      (fun tys ty =>
+        let! ty := mangle inds ty in
+        ret (tys +++ "_" +++ ty))
+      tycon tys
+  | tInd ind n =>
+    let! '(mbody, _, _) := findM ind.(inductive_mind) inds in
+    let! body := nthM_nat ind.(inductive_ind) mbody.(ind_bodies) in
+    ret body.(ind_name)
+  | tConstruct ind n _ =>
+    let! '(mbody, _, _) := findM ind.(inductive_mind) inds in
+    let! body := nthM_nat ind.(inductive_ind) mbody.(ind_bodies) in
+    let! '(c, _, _) := nthM_nat n body.(ind_ctors) in
+    ret c
+  | tConst kername _ => ret (unqualified kername)
+  | e => raise ("mangle: Unrecognized type: " +++ string_of_term e)
+  end.
+
+Fixpoint decompose_sorts (ty : term) : list name × term :=
+  match ty with
+  | tProd n (tSort _) ty =>
+    let '(ns, ty) := decompose_sorts ty in
+    (n :: ns, ty)
+  | ty => ([], ty)
+  end.
+
+Definition tm_type_of (inds : ind_info) (ind : inductive) (n : nat) (pars : list term) : GM term :=
+  let! '(mbody, inductives, _) := findM ind.(inductive_mind) inds in
+  let! body := nthM_nat ind.(inductive_ind) mbody.(ind_bodies) in
+  let! '(c, cty, arity) := nthM_nat n body.(ind_ctors) in
+  let '(_, cty) := decompose_sorts cty in
+  let ind_env := (rev pars ++ rev_map (fun ind => tInd ind []) inductives)%list in
+  ret (subst0 ind_env cty).
+
+(* Types of constructors for ind specialized to pars *)
+Definition constr_types (inds : ind_info) (ind : inductive) (pars : list term)
+  : GM (list (string × (list term × term))) :=
+  let! '(mbody, _, _) := findM ind.(inductive_mind) inds in
+  let! body := nthM_nat ind.(inductive_ind) mbody.(ind_bodies) in
+  foldriM_nat
+    (fun n _ cs =>
+      let ctr := mkApps (tConstruct ind n []) pars in
+      let! ctr_ty := tm_type_of inds ind n pars in
+      let '(_, tys, rty) := decompose_prod ctr_ty in
+      let! c := mangle inds ctr in
+      ret ((c, (tys, rty)) :: cs))
+    [] body.(ind_ctors).
+
+Definition decompose_ind (decls : global_env) (ty : term) : GM (inductive × list term) :=
+  let fix go n ty {struct n} :=
+    let find_const n c :=
+      let! decl := findM' c decls "decompose_ind tConst" in
+      match decl with
+      | ConstantDecl {| cst_body := Some body |} => go n body
+      | ConstantDecl {| cst_body := None |} =>
+        raise ("decompose_ind: empty ConstantDecl body: " +++ c)
+      | InductiveDecl _ => raise ("decompose_ind: got InductiveDecl: " +++ c)
+      end
+    in
+    match n with O => raise "decompose_ind: OOF" | S n =>
+      match ty with
+      | tInd ind _ => ret (ind, [])
+      | tApp (tInd ind _) ts => ret (ind, ts)
+      | tConst kername _ => find_const n kername
+      (* TODO: support "higher kinded type aliases"
+         At present, writing recursive functions in TemplateMonad is prohibitively slow,
+         but eventually this whole function should be replaced by a call to tmEval. *)
+      | ty => raise ("decompose_ind: Unrecognized type: " +++ string_of_term ty)
+      end
+    end
+  in go 100%nat ty.
+
+Definition build_graph (atoms : list term) (p : program) : GM (ind_info × mind_graph_t) :=
+  let '(decls, ty) := p in
+  let inds := inductives_of_env decls in
+  let! atoms :=
+    fold_right
+      (fun '(k, v) m => insert k v m)
+      empty
+      <$> (let! ids := mapM (mangle inds) atoms in ret (combine ids atoms))
+  in
+  let fix go n ty g : GM mind_graph_t :=
+    let! '(ind, pars) := decompose_ind decls ty in
+    match n with O => ret g | S n =>
+      let! s := mangle inds ty in
+      if member s g.(mgTypes) then ret g else
+      let mgTypes := insert s ty g.(mgTypes) in
+      let! ctys := constr_types inds ind pars in
+      let mgConstrs := insert s (map fst ctys) g.(mgConstrs) in
+      let! mgChildren :=
+        foldriM
+          (fun n '(c, (tys, _)) m =>
+            let! tys := mapM (mangle inds) tys in
+            ret (insert c (n, tys, s) m))
+          g.(mgChildren) ctys
+      in
+      let g := mk_mg g.(mgAtoms) mgTypes mgConstrs mgChildren in
+      let! g :=
+        foldrM
+          (fun '(c, (tys, _)) g =>
+            foldrM (fun ty g => go n ty g) g tys)
+          g ctys
+      in
+      ret g
+    end
+  in
+  let! g := go 100%nat ty (mk_mg atoms atoms empty empty) in
+  ret (inds, g).
+
+(* Generate a type of depth-1 frames + associated operations *)
+
+Record frame := mk_frame {
+  hIndex : nat;
+  hName : string;
+  hConstr : term;
+  hLefts : list term;
+  hFrame : term;
+  hRights : list term;
+  hRoot : term }.
+
+Definition fn : term -> term -> term := tProd nAnon.
+Definition type0 := tSort Universe.type0.
+Definition func x t e := tLambda (nNamed x) t e.
+Definition lam t e := tLambda nAnon t e.
+
+Definition gen_univ_univD (typename : string) (g : mind_graph_t)
+  : ((mutual_inductive_entry × Map string N) × string) × term :=
+  let ty_u := typename +++ "_univ" in
+  let mgTypes := list_of_map g.(mgTypes) in
+  let tys := map (fun '(ty, _) => (ty, ty_u +++ "_" +++ ty)) mgTypes in
+  let ty_ns := foldri (fun n '(ty, _) m => insert ty n m) (fun _ => empty) tys in
+  let tys := map snd tys in
+  let ind_entry : one_inductive_entry := {|
+    mind_entry_typename := ty_u;
+    mind_entry_arity := type0;
+    mind_entry_template := false;
+    mind_entry_consnames := tys;
+    mind_entry_lc := repeat (tRel 0) #|tys| |}
+  in
+  let univ_ind := mkInd (typename +++ "_univ") 0 in
+  let univ := tInd univ_ind [] in
+  let body :=
+    func "u" univ
+      (tCase (univ_ind, O)
+        (lam univ type0)
+        (tRel 0) (map (fun '(_, ty) => (O, ty)) mgTypes))
+  in ({|
+    mind_entry_record := None;
+    mind_entry_finite := Finite;
+    mind_entry_params := [];
+    mind_entry_inds := [ind_entry];
+    mind_entry_universes := Monomorphic_entry (LevelSet.empty, ConstraintSet.empty);
+    mind_entry_variance := None;
+    mind_entry_private := None |}, ty_ns, typename +++ "_univD", body).
+
+Definition holes_of {A} (xs : list A) : list ((list A × A) × list A) :=
+  let fix go l xs :=
+    match xs with
+    | [] => []
+    | x :: xs => (rev l, x, xs) :: go (x :: l) xs
+    end
+  in go [] xs.
+
+Definition gen_frames (decls : global_env) (g : mind_graph_t)
+  : GM (list frame × Map string (list frame)) :=
+  let! cfs :=
+    foldrM
+      (fun '(c, (n_constr, tys, rty)) hs =>
+        let! tys := mapM (fun ty => findM ty g.(mgTypes)) tys in
+        let! rty := findM rty g.(mgTypes) in
+        let! '(ind, pars) := decompose_ind decls rty in
+        foldriM
+          (fun n_arg '(l, x, r) hs =>
+            ret ((c, {|
+              hIndex := 0; (* bogus! filled in below *)
+              hName := c +++ string_of_N n_arg;
+              hConstr := mkApps (tConstruct ind (N.to_nat n_constr) []) pars;
+              hLefts := l;
+              hFrame := x;
+              hRights := r;
+              hRoot := rty |}) :: hs))
+          hs (holes_of tys))
+      [] (list_of_map g.(mgChildren))
+  in
+  ret (foldri_nat
+    (fun i '(c, f) '(fs, m) =>
+      let f := mk_frame i f.(hName) f.(hConstr) f.(hLefts) f.(hFrame) f.(hRights) f.(hRoot) in
+      (f :: fs, update c (cons f) [] m))
+    (fun _ => ([], empty))
+    cfs).
+
+Definition index_of {A} (f : A -> bool) (xs : list A) : GM nat :=
+  let fix go n xs :=
+    match xs with
+    | [] => raise "index_of: not found"
+    | x :: xs => if f x then ret n else go (S n) xs
+    end
+  in go O xs.
+
+Definition gen_frame_t (typename : string) (inds : ind_info) (g : mind_graph_t) (fs : list frame)
+  : GM mutual_inductive_entry :=
+  let univ := tInd (mkInd (typename +++ "_univ") 0) [] in
+  let to_univ ty :=
+    let! mangled := mangle inds ty in
+    let! n := index_of (fun '(s, _) => eq_string s mangled) (list_of_map g.(mgTypes)) in
+    ret (tConstruct (mkInd (typename +++ "_univ") 0) n [])
+  in
+  let! ctr_types :=
+    mapM
+      (fun '(mk_frame _ _ _ ls t rs root) =>
+        let! args := mapM to_univ [t; root] in
+        let rty := mkApps (tRel #|ls ++ rs|) args in
+        ret (fold_right fn (fold_right fn rty rs) ls))
+      fs
+  in
+  let ind_entry : one_inductive_entry := {|
+    mind_entry_typename := typename +++ "_frame_t";
+    mind_entry_arity := fn univ (fn univ type0);
+    mind_entry_template := false;
+    mind_entry_consnames := map (fun h => h.(hName)) fs;
+    mind_entry_lc := ctr_types |}
+  in
+  ret {|
+    mind_entry_record := None;
+    mind_entry_finite := Finite;
+    mind_entry_params := [];
+    mind_entry_inds := [ind_entry];
+    mind_entry_universes := Monomorphic_entry (LevelSet.empty, ConstraintSet.empty);
+    mind_entry_variance := None;
+    mind_entry_private := None |}.
+
+Definition gen_frameD (typename : string) (univD_kername : string) (fs : list frame)
+  : string × term :=
+  let univ_ty := tInd (mkInd (typename +++ "_univ") O) [] in
+  let univD ty := mkApps (tConst univD_kername []) [ty] in
+  let frame_ind := mkInd (typename +++ "_frame_t") O in
+  let frame_ty := mkApps (tInd frame_ind []) [tRel 1; tRel O] in
+  let mk_arm h :=
+    let 'mk_frame _ name constr lefts frame rights root := h in
+    let ctr_arity := #|lefts ++ rights| in
+    let indices := rev (seq (1 + #|rights|) #|lefts|) ++ [O] ++ rev (seq 1 #|rights|) in
+    let add_arg arg_ty body := lam arg_ty body in
+    (ctr_arity, fold_right lam (fold_right lam (lam frame (mkApps constr (map tRel indices))) rights) lefts)
+  in
+  let body :=
+    func "A" univ_ty (func "B" univ_ty (func "h" frame_ty
+      (tCase (frame_ind, O)
+        (func "A" univ_ty (func "B" univ_ty (func "h" frame_ty
+          (fn (univD (tRel 2)) (univD (tRel 2))))))
+        (tRel O) (map mk_arm fs))))
+  in
+  (typename +++ "_frameD", body).
+
+Definition kername_of_const (s : string) : TemplateMonad string :=
+  ref <- tmAbout s ;;
+  match ref with
+  | Some (ConstRef kername) => TM.ret kername
+  | Some _ => tmFail ("kername_of_const: Not a constant: " +++ s)
+  | None => tmFail ("kername_of_const: Not in scope: " +++ s)
+  end.
+
+Definition gen_Frame_ops (typename : string) (T : program) (atoms : list term) : GM _ :=
+  let! '(inds, g) := build_graph atoms T in
+  let! '(fs, cfs) := gen_frames (fst T) g in
+  let '(univ, univ_of_tyname, univD, univD_body) := gen_univ_univD typename g in
+  let! frame_t := gen_frame_t typename inds g fs in
+  ret (inds, g, fs, cfs, univ, univ_of_tyname, univD, univD_body, frame_t).
+
+Record aux_data_t := mk_aux_data {
+  aEnv : global_env;
+  aIndInfo : ind_info;
+  aTypename : string;
+  aGraph : mind_graph_t;
+  aUnivOfTyname : Map string N;
+  aFramesOfConstr : Map string (list frame) }.
+
+Class AuxData (U : Set) := aux_data : aux_data_t.
+
+Definition mk_Frame_ops (typename : string) (T : Type) (atoms : list Set) : TemplateMonad unit :=
+  p <- tmQuoteRec T ;;
+  atoms <- monad_map tmQuote atoms ;;
+  mlet (inds, g, fs, cfs, univ, univ_of_tyname, univD, univD_body, frame_t) <-
+    runGM (gen_Frame_ops typename p atoms) ;;
+  tmMkInductive univ ;;
+  tmMkDefinition univD univD_body ;;
+  tmMkInductive frame_t ;;
+  univD_kername <- kername_of_const univD ;;
+  let '(frameD, frameD_body) := gen_frameD typename univD_kername fs in
+  tmMkDefinition frameD frameD_body ;;
+  tmMkDefinition (typename +++ "_Frame_ops") (
+    mkApps (tConstruct (mkInd "Frame" 0) 0 []) [
+      tInd (mkInd (typename +++ "_univ") 0) [];
+      tConst (typename +++ "_univD") [];
+      tInd (mkInd (typename +++ "_frame_t") 0) [];
+         tConst (typename +++ "_frameD") []]) ;;
+  tmDefinition (typename +++ "_aux_data")
+               (mk_aux_data (fst p) inds typename g univ_of_tyname cfs) ;;
+  ret tt.

--- a/theories/L6_PCPS/PrototypeTests.v
+++ b/theories/L6_PCPS/PrototypeTests.v
@@ -1,0 +1,786 @@
+From CertiCoq.L6 Require Import MockExpr Prototype.
+
+Require Import Coq.Strings.Ascii Coq.Strings.String.
+Infix "+++" := append (at level 60, right associativity).
+
+Require Import Coq.Lists.List.
+Import ListNotations.
+
+From MetaCoq Require Import Template.All.
+Import MonadNotation.
+
+From ExtLib.Core Require Import RelDec.
+From ExtLib.Data Require Import Nat List Option Pair String.
+From ExtLib.Structures Require Import Monoid Functor Applicative Monads Traversable.
+From ExtLib.Data.Monads Require Import IdentityMonad EitherMonad StateMonad.
+
+Require Import Coq.NArith.BinNat.
+Local Open Scope N_scope.
+
+Require Import Coq.Relations.Relations.
+
+Require Import Ltac2.Ltac2.
+Import Ltac2.Notations.
+
+Set Default Proof Mode "Ltac2".
+
+Unset Strict Unquote Universe Mode.
+
+(* ---------- Example ---------- *)
+
+Instance Frame_exp_inj : @Frame_inj exp_univ _.
+Proof. unfold Frame_inj; destruct f; simpl; ltac1:(congruence). Defined.
+
+Check frames_nil >:: cons_fundef0 [] >:: fFun2 0%nat [].
+Check fun e => <[ cons_fundef0 []; fFun2 0%nat [] ]> ⟦ e ⟧.
+
+Definition used_vars_var : var -> list var := fun x => [x].
+Definition used_vars_constr : constr -> list var := fun _ => [].
+Definition used_vars_list_var : list var -> list var := fun xs => xs.
+Definition used_vars_list {A} (f : A -> list var) (xs : list A) : list var := concat (map f xs).
+Definition used_vars_arm' used_vars_exp : constr * exp -> list var := fun '(_, e) => used_vars_exp e.
+Fixpoint used_vars_exp (e : exp) : list var :=
+  match e with
+  | eHalt x => [x]
+  | eApp f xs => f :: xs
+  | eCons x c ys e => x :: ys ++ used_vars_exp e
+  | eProj x y n e => x :: y :: used_vars_exp e
+  | eCase x arms => x :: used_vars_list (used_vars_arm' used_vars_exp) arms
+  | eFuns fds e => used_vars_list used_vars_fundef fds ++ used_vars_exp e
+  end
+with used_vars_fundef (fd : fundef) :=
+  let 'fFun f xs e := fd in
+  f :: xs ++ used_vars_exp e.
+Definition used_vars_arm := used_vars_arm' used_vars_exp.
+
+(* Example: commonly want to track max used vars for fresh name generation *)
+Definition used_vars_prop {A : exp_univ} (C : frames_t A exp_univ_exp) (e : univD A) (x : var) : Prop :=
+  ~ In x (used_vars_exp (C ⟦ e ⟧)).
+
+(* When just moving up and down, next fresh var doesn't need to be updated *)
+
+Instance Preserves_S_dn_exp : Preserves_S_dn (@used_vars_prop).
+Proof. intros A B C C_ok f x; destruct f; unfold used_vars_prop; simpl; intros; assumption. Defined.
+
+Instance Preserves_S_up_exp : Preserves_S_up (@used_vars_prop).
+Proof. intros A B C C_ok f x; destruct f; unfold used_vars_prop; simpl; intros; assumption. Defined.
+
+Extraction Inline Preserves_S_dn_exp Preserves_S_up_exp.
+
+(* ---------- Mock relation + state for testing ---------- *)
+
+Inductive R : exp -> exp -> Prop :=
+| R0 : forall (C : frames_t exp_univ_exp exp_univ_exp) x c ys ys' e,
+    ys' = ys ++ ys ->
+    R (C⟦eCons x c ys e⟧) (C⟦eCons x c ys' (Rec e)⟧)
+| R1 : forall (C : frames_t exp_univ_exp exp_univ_exp) x c y ys ys' e,
+    #|ys| = 4%nat ->
+    (forall D : frames_t exp_univ_exp exp_univ_exp, D >++ C = D >++ C) ->
+    e = e ->
+    ys' = ys ++ [y; y] ->
+    R (C⟦eCons x c (y :: ys) e⟧) (C⟦eCons x c ys' (Rec e)⟧)
+| R2 : forall (C : frames_t exp_univ_list_fundef exp_univ_exp) f x xs xs' e fds,
+    #|xs| = 0%nat ->
+    xs ++ [x] = xs' ->
+    C = C ->
+    BottomUp (R (C⟦fFun f (x :: xs) e :: fds⟧) (C⟦fFun f xs' e :: fds⟧))
+| R3 : forall (C : frames_t exp_univ_list_fundef exp_univ_exp) f x x' xs xs' e fds,
+    #|xs| = 0%nat ->
+    xs ++ [x] = xs' ->
+    C = C ->
+    BottomUp (R (C⟦fFun f (x :: x' :: xs) e :: fds⟧) (C⟦fFun f xs' e :: fds⟧)).
+
+Definition I_R {A} (C : frames_t A exp_univ_exp) (n : nat) : Prop := C = C.
+
+Definition I_S {A} (C : frames_t A exp_univ_exp) (x : univD A) (n : nat) : Prop := C⟦x⟧ = C⟦x⟧.
+
+Instance Preserves_R_R_C : Preserves_R (@I_R).
+Proof. intros A B C C_ok f [n _]; exists n; unerase; reflexivity. Defined.
+
+Instance Preserves_S_dn_St : Preserves_S_dn (@I_S).
+Proof. intros A B C C_ok f x [n _]; exists n; unerase; reflexivity. Defined.
+
+Instance Preserves_S_up_St : Preserves_S_up (@I_S).
+Proof. intros A B C C_ok f x [n _]; exists n; unerase; reflexivity. Defined.
+
+Extraction Inline Preserves_R_R_C Preserves_S_dn_St Preserves_S_up_St.
+
+(* Run TemplateProgram (tmPrint =<< parse_rel R). *) (* For some reason, this hangs.. *)
+
+(* ...but this doesn't: *)
+Goal True.
+  ltac1:(parse_rel 0 R ltac:(fun x n => idtac x)).
+Abort.
+
+Goal True.
+  ltac1:(
+    parse_rel 0 R ltac:(fun rules n =>
+    run_template_program (
+      fueled' <- tmQuote true ;;
+      metric' <- tmQuote tt ;;
+      I_D' <- tmQuote (@I_D_plain exp_univ Frame_exp unit) ;;
+      D' <- tmQuote unit ;;
+      I_D' <- tmQuote (@I_D_plain exp_univ Frame_exp unit) ;;
+      R' <- tmQuote nat ;;
+      I_R' <- tmQuote (@I_R) ;;
+      S' <- tmQuote nat ;;
+      I_S' <- tmQuote (@I_S) ;;
+      delayD <- tmQuote (@delayD exp_univ Frame_exp unit (@I_D_plain exp_univ Frame_exp unit) _) ;;
+      ret (fueled', metric', D', I_D', R', I_R', S', I_S', delayD)) ltac:(fun pack =>
+    lazymatch pack with
+    | (?fueled', ?metric', ?D', ?I_D', ?R', ?I_R', ?S', ?I_S', ?delayD) =>
+      runGM n (
+        let! fueled'' := named_of [] fueled' in
+        let! metric'' := named_of [] metric' in
+        let! D'' := named_of [] D' in
+        let! I_D'' := named_of [] I_D' in
+        let! delayD' := named_of [] delayD in
+        let! R'' := named_of [] R' in
+        let! I_R'' := named_of [] I_R' in
+        let! S'' := named_of [] S' in
+        let! I_S'' := named_of [] I_S' in
+        gen_extra_vars_tys AuxData_exp rules D'' I_D'' R'' I_R'' S'' I_S'' delayD') ltac:(fun qobs n =>
+        run_template_program (
+          (* tmPrint qobs ;; *)
+          (* tmReturn tt) *)
+          obs' <- monad_map tmUnquote qobs ;;
+          tmPrint obs')
+          ltac:(fun x => idtac))
+    end))).
+Abort.
+
+Goal True.
+  ltac1:(
+    parse_rel 0 R ltac:(fun rules n =>
+    run_template_program (
+      fueled' <- tmQuote true ;;
+      metric' <- tmQuote tt ;;
+      I_D' <- tmQuote (@I_D_plain exp_univ Frame_exp unit) ;;
+      D' <- tmQuote unit ;;
+      I_D' <- tmQuote (@I_D_plain exp_univ Frame_exp unit) ;;
+      R' <- tmQuote nat ;;
+      I_R' <- tmQuote (@I_R) ;;
+      S' <- tmQuote nat ;;
+      I_S' <- tmQuote (@I_S) ;;
+      delayD <- tmQuote (@delayD exp_univ Frame_exp unit (@I_D_plain exp_univ Frame_exp unit) _) ;;
+      ret (fueled', metric', D', I_D', R', I_R', S', I_S', delayD)) ltac:(fun pack =>
+    lazymatch pack with
+    | (?fueled', ?metric', ?D', ?I_D', ?R', ?I_R', ?S', ?I_S', ?delayD) =>
+      runGM n (
+        let! fueled'' := named_of [] fueled' in
+        let! metric'' := named_of [] metric' in
+        let! D'' := named_of [] D' in
+        let! I_D'' := named_of [] I_D' in
+        let! delayD' := named_of [] delayD in
+        let! R'' := named_of [] R' in
+        let! I_R'' := named_of [] I_R' in
+        let! S'' := named_of [] S' in
+        let! I_S'' := named_of [] I_S' in
+        gen_run_rule_tys rules fueled'' metric'' R'' I_R'' S'' I_S'') ltac:(fun qobs n =>
+        run_template_program (
+          (* tmPrint qobs ;; *)
+          (* tmReturn tt) *)
+          obs' <- monad_map tmUnquote qobs ;;
+          tmPrint obs')
+          ltac:(fun x => idtac))
+    end))).
+Abort.
+
+Goal True.
+  ltac1:(
+    parse_rel 0 R ltac:(fun rules n =>
+    run_template_program (
+      fueled' <- tmQuote true ;;
+      metric' <- tmQuote tt ;;
+      I_D' <- tmQuote (@I_D_plain exp_univ Frame_exp unit) ;;
+      D' <- tmQuote unit ;;
+      I_D' <- tmQuote (@I_D_plain exp_univ Frame_exp unit) ;;
+      R' <- tmQuote nat ;;
+      I_R' <- tmQuote (@I_R) ;;
+      S' <- tmQuote nat ;;
+      I_S' <- tmQuote (@I_S) ;;
+      delayD <- tmQuote (@delayD exp_univ Frame_exp unit (@I_D_plain exp_univ Frame_exp unit) _) ;;
+      ret (fueled', metric', D', I_D', R', I_R', S', I_S', delayD)) ltac:(fun pack =>
+    lazymatch pack with
+    | (?fueled', ?metric', ?D', ?I_D', ?R', ?I_R', ?S', ?I_S', ?delayD) =>
+      runGM n (
+        let! fueled'' := named_of [] fueled' in
+        let! metric'' := named_of [] metric' in
+        let! D'' := named_of [] D' in
+        let! I_D'' := named_of [] I_D' in
+        let! delayD' := named_of [] delayD in
+        let! R'' := named_of [] R' in
+        let! I_R'' := named_of [] I_R' in
+        let! S'' := named_of [] S' in
+        let! I_S'' := named_of [] I_S' in
+        gen_constr_delay_tys AuxData_exp rules D'' I_D'' delayD') ltac:(fun qobs n =>
+        run_template_program (
+          (* tmPrint qobs ;; *)
+          (* tmReturn tt) *)
+          obs' <- monad_map tmUnquote qobs ;;
+          tmPrint obs')
+          ltac:(fun x => idtac))
+    end))).
+Abort.
+
+Goal True.
+  ltac1:(
+    parse_rel 0 R ltac:(fun rules n =>
+    run_template_program (
+      fueled' <- tmQuote true ;;
+      metric' <- tmQuote tt ;;
+      I_D' <- tmQuote (@I_D_plain exp_univ Frame_exp unit) ;;
+      D' <- tmQuote unit ;;
+      I_D' <- tmQuote (@I_D_plain exp_univ Frame_exp unit) ;;
+      R' <- tmQuote nat ;;
+      I_R' <- tmQuote (@I_R) ;;
+      S' <- tmQuote nat ;;
+      I_S' <- tmQuote (@I_S) ;;
+      delayD <- tmQuote (@delayD exp_univ Frame_exp unit (@I_D_plain exp_univ Frame_exp unit) _) ;;
+      ret (fueled', metric', D', I_D', R', I_R', S', I_S', delayD)) ltac:(fun pack =>
+    lazymatch pack with
+    | (?fueled', ?metric', ?D', ?I_D', ?R', ?I_R', ?S', ?I_S', ?delayD) =>
+      runGM n (
+        let! fueled'' := named_of [] fueled' in
+        let! metric'' := named_of [] metric' in
+        let! D'' := named_of [] D' in
+        let! I_D'' := named_of [] I_D' in
+        let! delayD' := named_of [] delayD in
+        let! R'' := named_of [] R' in
+        let! I_R'' := named_of [] I_R' in
+        let! S'' := named_of [] S' in
+        let! I_S'' := named_of [] I_S' in
+        gen_smart_constr_tys AuxData_exp rules fueled'' metric'' R'' I_R'' S'' I_S'') ltac:(fun qobs n =>
+        run_template_program (
+          (* tmPrint qobs ;; *)
+          (* tmReturn tt) *)
+          obs' <- monad_map tmUnquote qobs ;;
+          tmPrint obs')
+          ltac:(fun x => idtac))
+    end))).
+Abort.
+
+Definition test_case_tree (pat pat_ty ret_ty success failure : term) : TemplateMonad unit :=
+  mlet (ast, nameless) <- runGM (
+    let! ast :=
+      gen_case_tree exp_aux_data.(aIndInfo) [(tVar "$input", pat)] ret_ty success failure
+    in
+    let ast := tLambda (nNamed "$input") pat_ty ast in
+    let! nameless := indices_of [] ast in
+    (* let nameless := tRel 0 in *)
+    ret (ast, nameless)) ;;
+  (* print_nf nameless ;; *)
+  tm <- tmUnquote nameless ;;
+  tmPrint tm ;;
+  print_nf ast ;;
+  ret tt.
+
+(*
+Compute runGM' 0 (gen_case_tree exp_aux_data.(aIndInfo)
+  [(tVar "discr", mkApps <%S%> [mkApps <%S%> [mkApps <%S%> [tVar "n"]]])] <%nat%> <%true%> <%false%>).
+
+Compute <%(0, eApp 0 [])%>.
+Run TemplateProgram (test_case_tree <%3%nat%> <%nat%> <%bool%> <%true%> <%false%>).
+Run TemplateProgram (test_case_tree <%@nil nat%> <%list nat%> <%bool%> <%true%> <%false%>).
+Run TemplateProgram (test_case_tree <%eApp 0 []%> <%exp%> <%bool%> <%true%> <%false%>).
+Run TemplateProgram (test_case_tree <%(0, eApp 0 [])%> <%(constr * exp)%type%>
+                                   <%bool%> <%true%> <%false%>).
+Run TemplateProgram (test_case_tree <%eCase 1 [(0, eApp 0 [])]%> <%exp%>
+                                   <%bool%> <%true%> <%false%>).
+Run TemplateProgram (test_case_tree
+  (mkApps <%eCase%> [tVar "$n"; mkApps <%@cons (constr * exp)%type%> [
+    mkApps <%@pair constr exp%> [tVar "$m";
+    mkApps <%eApp%> [<%0%>; <%@nil var%>]]; <%@nil (constr * exp)%type%>]])
+  <%exp%> <%nat%> (mkApps <%plus%> [tVar "$n"; tVar "$m"]) <%O%>).
+*)
+
+Goal True.
+  ltac1:(
+    parse_rel 0 R ltac:(fun rules n =>
+    run_template_program (
+      fueled' <- tmQuote true ;;
+      metric' <- tmQuote tt ;;
+      I_D' <- tmQuote (@I_D_plain exp_univ Frame_exp unit) ;;
+      D' <- tmQuote unit ;;
+      I_D' <- tmQuote (@I_D_plain exp_univ Frame_exp unit) ;;
+      R' <- tmQuote nat ;;
+      I_R' <- tmQuote (@I_R) ;;
+      S' <- tmQuote nat ;;
+      I_S' <- tmQuote (@I_S) ;;
+      delayD <- tmQuote (@delayD exp_univ Frame_exp unit (@I_D_plain exp_univ Frame_exp unit) _) ;;
+      ret (fueled', metric', D', I_D', R', I_R', S', I_S', delayD)) ltac:(fun pack =>
+    lazymatch pack with
+    | (?fueled', ?metric', ?D', ?I_D', ?R', ?I_R', ?S', ?I_S', ?delayD) =>
+      runGM n (
+        let! fueled'' := named_of [] fueled' in
+        let! metric'' := named_of [] metric' in
+        let! D'' := named_of [] D' in
+        let! I_D'' := named_of [] I_D' in
+        let! delayD' := named_of [] delayD in
+        let! R'' := named_of [] R' in
+        let! I_R'' := named_of [] I_R' in
+        let! S'' := named_of [] S' in
+        let! I_S'' := named_of [] I_S' in
+        gen_inspect_tys AuxData_exp rules D'' I_D'' R'' I_R'' S'' I_S'' delayD') ltac:(fun qobs n =>
+        run_template_program (
+          let '(topdown, bottomup) := qobs in
+          topdown' <- monad_map tmUnquote topdown ;;
+          bottomup' <- monad_map tmUnquote bottomup ;;
+          tmPrint "-------------------- topdown --------------------" ;;
+          tmPrint topdown' ;;
+          tmPrint "-------------------- bottomup --------------------" ;;
+          tmPrint bottomup')
+          ltac:(fun x => idtac))
+    end))).
+Abort.
+
+(* Context (opaque_delay_t : forall {A : exp_univ}, univD A -> Set) *)
+(*        `{Hopaque_delay : @Delayed exp_univ Frame_exp (@opaque_delay_t)}. *)
+Definition opaque_delay_t {A : exp_univ} (e : univD A) := unit.
+
+Definition const_fun {A B} (x : A) (y : B) : B := y.
+
+Inductive R' : exp -> exp -> Prop :=
+| R'0 : forall (C : frames_t exp_univ_exp exp_univ_exp) x c ys ys' e,
+    ys' = ys ++ ys ->
+    R' (C⟦eCons x c ys e⟧) (C⟦eCons x c ys' (Rec (const_fun tt e))⟧)
+| R'1 : forall (C : frames_t exp_univ_exp exp_univ_exp) x c y ys ys' e,
+    #|ys| = 4%nat /\
+    (forall D : frames_t exp_univ_exp exp_univ_exp, D >++ C = D >++ C) /\
+    e = e /\
+    ys' = ys ++ [y; y] ->
+    R' (C⟦eCons x c (y :: ys) e⟧) (C⟦eCons x c ys' (Rec e)⟧)
+| R'4 : forall (C : frames_t exp_univ_exp exp_univ_exp) x c ys e,
+    R' (C⟦eCons x c ys e⟧) (C⟦eCons x c ys (eCons x c ys (Rec e))⟧)
+| R'2 : forall (C : frames_t exp_univ_list_fundef exp_univ_exp) f x xs xs' e fds,
+    #|xs| = 0%nat /\
+    xs ++ [x] = xs' /\
+    C = C ->
+    BottomUp (R' (C⟦fFun f (x :: xs) e :: fds⟧) (C⟦fFun f xs' e :: fds⟧))
+| R'3 : forall (C : frames_t exp_univ_list_fundef exp_univ_exp) f x x' xs xs' e fds,
+    #|xs| = 0%nat /\
+    xs ++ [x] = xs' /\
+    C = C ->
+    BottomUp (R' (C⟦fFun f (x :: x' :: xs) e :: fds⟧) (C⟦fFun f xs' e :: fds⟧)).
+
+Goal True.
+  ltac1:(
+  parse_rel 0 R' ltac:(fun rules n => idtac rules n)).
+Abort.
+
+Definition rw_R : rewriter exp_univ_exp true tt R' unit (I_D_plain (U:=exp_univ) (D:=unit)) nat (@I_R) nat (@I_S).
+Proof.
+  ltac1:(mk_rw';
+    try lazymatch goal with
+    | |- SmartConstr _ -> _ => mk_smart_constr
+    | |- RunRule _ -> _ => mk_run_rule
+    | |- Topdown _ -> _ => mk_topdown
+    | |- Bottomup _ -> _ => mk_bottomup
+    end;
+    (* This particular rewriter's delayed computation is just the identity function, *)
+    (* so ConstrDelay is easy *)
+    try lazymatch goal with
+    | |- ConstrDelay _ -> _ => mk_easy_delay
+    end;
+    (* try lazymatch goal with *)
+    (* | |- ExtraVars _ -> _ => admit *)
+    (* end; *)
+    [..|mk_rewriter];
+    idtac).
+  { cbn; intros; ltac1:(cond_success success).
+    eapply success; eauto.
+    ltac1:(unshelve econstructor; [exact O|unerase; reflexivity]). }
+  { cbn; intros; ltac1:(cond_failure). }
+  { cbn; intros; ltac1:(cond_success success); eapply success; eauto.
+    ltac1:(unshelve econstructor; [exact O|unerase; reflexivity]). }
+  { cbn; intros; ltac1:(cond_failure). }
+  { cbn; intros; ltac1:(cond_failure). }
+Defined.
+
+Set Extraction Flag 2031. (* default + linear let + linear beta *)
+Recursive Extraction rw_R.
+(* - is directly recursive (fixpoint combinator gone) 
+   - context parameter erased *)
+
+Definition size_ctor : constr -> nat := fun _ => 1%nat.
+Definition size_var : var -> nat := fun _ => 1%nat.
+Definition size_list {A} (size : A -> nat) (xs : list A) : nat :=
+  (fold_right (fun x n => 1 + size x + n) 1 xs)%nat.
+Definition size_vars := size_list size_var.
+Fixpoint size_exp (e : exp) : nat :=
+  match e with
+  | eHalt x => 1 + size_var x
+  | eApp f xs => 1 + size_var f + size_vars xs
+  | eCons x c ys e => 1 + size_var x + size_ctor c + size_vars ys + size_exp e
+  | eProj x y n e => 1 + size_var x + size_var y + n + size_exp e
+  | eCase x arms => 1 + size_var x + size_list (fun '(c, e) => 1 + size_ctor c + size_exp e) arms
+  | eFuns fds e => 1 + size_list size_fd fds + size_exp e
+  end%nat
+with size_fd (fd : fundef) : nat :=
+  let 'fFun f xs e := fd in
+  1 + size_var f + size_vars xs + size_exp e.
+
+Definition size {A} : univD A -> nat :=
+  match A with
+  | exp_univ_prod_constr_exp => fun '(c, e) => 1 + size_ctor c + size_exp e
+  | exp_univ_list_prod_constr_exp => size_list (fun '(c, e) => 1 + size_ctor c + size_exp e)
+  | exp_univ_fundef => size_fd
+  | exp_univ_list_fundef => size_list size_fd
+  | exp_univ_exp => size_exp
+  | exp_univ_var => size_var
+  | exp_univ_constr => size_ctor
+  | exp_univ_nat => id
+  | exp_univ_list_var => size_vars
+  end%nat.
+
+Require Import Lia.
+
+Definition rw_R_m :
+  rewriter exp_univ_exp false (fun A C e => size e) R' unit (I_D_plain (U:=exp_univ) (D:=unit)) nat (@I_R) nat (@I_S).
+Proof.
+  ltac1:(mk_rw';
+    try lazymatch goal with
+    | |- SmartConstr _ -> _ => mk_smart_constr
+    | |- RunRule _ -> _ => mk_run_rule
+    | |- Topdown _ -> _ => mk_topdown
+    | |- Bottomup _ -> _ => mk_bottomup
+    end;
+    try lazymatch goal with
+    (* This particular rewriter's delayed computation is just the identity function, *)
+    (* so ConstrDelay is easy *)
+    | |- ConstrDelay _ -> _ => mk_easy_delay
+    end;
+    (* try lazymatch goal with *)
+    (* | |- ExtraVars _ -> _ => admit *)
+    (* end; *)
+    [..|mk_rewriter];
+    try lazymatch goal with
+    (* Solve easy obligations about termination *)
+    | |- MetricDecreasing -> _ => intros _; cbn; lia
+    end;
+    idtac).
+  { cbn; intros; ltac1:(cond_success success).
+    eapply success; eauto.
+    ltac1:(unshelve econstructor; [exact O|unerase; reflexivity]). }
+  { cbn; intros; ltac1:(cond_failure). }
+  { cbn; intros; ltac1:(cond_success success); eapply success; eauto.
+    ltac1:(unshelve econstructor; [exact O|unerase; reflexivity]). }
+  { cbn; intros; ltac1:(cond_failure). }
+  { cbn; intros; ltac1:(cond_failure). }
+  { intros _; rewrite <- H1. unfold const_fun; cbn; ltac1:(lia). }
+  { intros _; rewrite <- H1. cbn; ltac1:(lia). }
+  { intros _; rewrite <- H0. cbn; ltac1:(lia). }
+Defined.
+
+Set Extraction Flag 2031. (* default + linear let + linear beta *)
+Recursive Extraction rw_R_m.
+(* - is directly recursive (fixpoint combinator gone) 
+   - context parameter erased
+   - no fuel parameter (termination argument erased) *)
+
+(*
+Compute rw_R'' (xI xH) exp_univ_exp <[]>
+  (eCons 0 0 [] (eApp 1 []))
+  tt
+  {| envVal := 0; envPrf := eq_refl |}
+  {| stVal := 0; stPrf := eq_refl |}. *)
+
+(* -------------------- Another example -------------------- *)
+
+Instance Eq_var : Eq var := {rel_dec := fun n m => n ==? m}.
+
+Definition renaming := var -> var.
+
+Definition one_renaming x y := fun x' => if x ==? x' then y else x'.
+
+Definition subst_arm' (subst_exp : (var -> var) -> exp -> exp) (σ : var -> var)
+  : _ -> constr * exp := fun '(c, e) => (c, subst_exp σ e).
+Fixpoint subst_exp σ e :=
+  match e with
+  | eHalt x => eHalt (σ x)
+  | eApp f xs => eApp (σ f) (map σ xs)
+  | eCons x c ys e => eCons (σ x) c (map σ ys) (subst_exp σ e)
+  | eProj x y n e => eProj (σ x) (σ y) n (subst_exp σ e)
+  | eCase x arms => eCase (σ x) (map (subst_arm' subst_exp σ) arms)
+  | eFuns fds e => eFuns (map (subst_fd σ) fds) (subst_exp σ e)
+  end
+with subst_fd σ fd :=
+  let 'fFun f xs e := fd in
+  fFun (σ f) (map σ xs) (subst_exp σ e).
+Definition subst_arm := subst_arm' subst_exp.
+
+Lemma map_id {A} (f : A -> A) xs : (forall x, f x = x) -> map f xs = xs.
+Proof. induction xs as [|x xs IHxs]; auto; simpl; intros; now rewrite IHxs. Defined.
+
+Lemma subst_exp_id σ e : (forall x, σ x = x) -> subst_exp σ e = e
+with subst_fd_id σ fd : (forall x, σ x = x) -> subst_fd σ fd = fd.
+Proof.
+  - intros Hσ; destruct e; simpl.
+    + now rewrite Hσ.
+    + now rewrite Hσ, map_id.
+    + now rewrite Hσ, map_id, subst_exp_id.
+    + now rewrite Hσ, subst_exp_id.
+    + induction arms as [|[] arms Harms]; simpl; try ltac1:(congruence).
+      rewrite Hσ in *; do 2 f_equal.
+      * now rewrite subst_exp_id.
+      * ltac1:(congruence).
+    + rewrite subst_exp_id > [|assumption]; f_equal.
+      induction fds; auto; simpl.
+      rewrite subst_fd_id > [|assumption]; f_equal; assumption.
+  - intros Hσ; destruct fd; simpl.
+    now rewrite Hσ, map_id, subst_exp_id.
+Defined.
+
+Lemma map_comp {A} (f g : A -> A) xs : map (f ∘ g) xs = map f (map g xs).
+Proof. induction xs as [|x xs IHxs]; auto; simpl; intros; now rewrite IHxs. Defined.
+
+Lemma subst_exp_comp σ1 σ2 e : subst_exp (σ1 ∘ σ2) e = subst_exp σ1 (subst_exp σ2 e)
+with subst_fd_comp σ1 σ2 fd : subst_fd (σ1 ∘ σ2) fd = subst_fd σ1 (subst_fd σ2 fd).
+Proof.
+  - destruct e; simpl; f_equal; try (now (rewrite map_comp)); try (now (apply subst_exp_comp)).
+    + induction arms as [|[] arm Harm]; auto; simpl.
+      rewrite subst_exp_comp; now f_equal.
+    + induction fds as [|[] fd Hfd]; auto; simpl.
+      rewrite subst_exp_comp, map_comp; now f_equal.
+  - destruct fd; simpl; f_equal > [now rewrite map_comp|now rewrite subst_exp_comp].
+Defined.
+
+Definition I_renaming A (e : univD A) (d : renaming) : Prop := True.
+Instance Delayed_renaming : Delayed (I_renaming).
+Proof.
+  ltac1:(unshelve econstructor).
+  - destruct A; simpl; intros x [σ _].
+    + exact (subst_arm σ x).
+    + exact (map (subst_arm σ) x).
+    + exact (subst_fd σ x).
+    + exact (map (subst_fd σ) x).
+    + exact (subst_exp σ x).
+    + exact (σ x).
+    + exact x.
+    + exact x.
+    + exact (map σ x).
+  - intros. exists id; exact I.
+  - intros [] []; simpl;
+      try ltac1:(match goal with p : constr * exp |- _ => destruct p; simpl end);
+      repeat (rewrite map_id);
+      repeat (rewrite subst_exp_id);
+      repeat (rewrite subst_fd_id);
+      try ltac1:(match goal with |- forall _ : constr * exp, _ => intros []; simpl end);
+      repeat (rewrite subst_exp_id);
+      try (now (intros; apply subst_fd_id; auto));
+      auto.
+Defined.
+Extraction Inline Delayed_renaming.
+
+Inductive cp_fold : exp -> exp -> Prop :=
+| cp_case_fold : forall (C : frames_t exp_univ_exp exp_univ_exp) x c ces e,
+    (exists D E ys, C = D >:: eCons3 x c ys >++ E) /\
+    (exists l r, ces = l ++ (c, e) :: r) ->
+    cp_fold
+      (C ⟦ eCase x ces ⟧)
+      (C ⟦ Rec e ⟧)
+| cp_proj_fold : forall (C : frames_t exp_univ_exp exp_univ_exp) x y y' ys n e,
+    (exists D E c, C = D >:: eCons3 y c ys >++ E) /\
+    nth_error ys n = Some y' ->
+    cp_fold
+      (C ⟦ eProj x y n e ⟧)
+      (C ⟦ Rec (subst_exp (one_renaming x y') e) ⟧).
+
+Definition I_cp_env {A} (C : frames_t A exp_univ_exp) (ρ : var -> option (constr × list var)) : Prop :=
+  forall x c ys, ρ x = Some (c, ys) ->
+  exists D E, C = D >:: eCons3 x c ys >++ E.
+
+Lemma eq_var_spec (x y : var) : Bool.reflect (x = y) (x ==? y).
+Proof.
+  simpl. destruct (PeanoNat.Nat.eqb_spec x y); constructor; ltac1:(congruence).
+Defined.
+
+Instance Preserves_cp_env : Preserves_R (@I_cp_env).
+Proof.
+  unfold I_cp_env; intros A B C C_ok f [ρ Hρ]; destruct f eqn:Heqf;
+  ltac1:(
+    match type of Heqf with
+    (* The case we care about *)
+    | _ = eCons3 _ _ _ => idtac
+    (* All other cases: just preserve the invariant *)
+    | _ =>
+      exists ρ; unerase; intros;
+      edestruct Hρ as [D [E Hctx]]; eauto;
+      rewrite Hctx; exists D; eexists;
+      match goal with
+      | |- ?C >++ ?D >:: ?e = _ =>
+        now change (C >++ D >:: e) with (C >++ (D >:: e))
+      end
+    end).
+  exists (fun v' => if v' ==? v then Some (c, l) else ρ v'); unerase.
+  intros v'; destruct (eq_var_spec v' v); intros c' l' Heq.
+  - inversion Heq; subst.
+    now exists C, <[]>.
+  - edestruct Hρ as [D [E Hctx]]; eauto.
+    rewrite Hctx.
+    do 2 eexists.
+    ltac1:(match goal with
+    | |- ?C >:: ?f1 >++ ?E >:: ?f2 = _ =>
+      now change (C >:: f1 >++ E >:: f2) with (C >:: f1 >++ (E >:: f2))
+    end).
+Defined.
+Extraction Inline Preserves_cp_env.
+
+Instance Eq_constr : Eq constr := {rel_dec := fun n m => n ==? m}.
+Lemma eq_constr_spec (x y : constr) : Bool.reflect (x = y) (x ==? y).
+Proof.
+  simpl.
+  destruct (PeanoNat.Nat.eqb_spec x y); constructor; ltac1:(congruence).
+Defined.
+
+Fixpoint find_arm (c : constr) (ces : list (constr * exp)) : option exp :=
+  match ces with
+  | [] => None
+  | (c', e) :: ces => if c ==? c' then Some e else find_arm c ces
+  end.
+
+Lemma find_arm_In : forall c e ces, find_arm c ces = Some e -> exists l r, ces = l ++ (c, e) :: r.
+Proof.
+  induction ces as [|[c' e'] ces Hces] > [inversion 1|].
+  unfold find_arm; fold find_arm.
+  destruct (eq_constr_spec c c'); intros Heq.
+  - inversion Heq; subst; now exists [], ces.
+  - destruct (Hces Heq) as [l [r Hlr]]; subst.
+    now exists ((c', e') :: l), r.
+Defined.
+
+Lemma app_as_ctx :
+  forall l ces c r e, ces = l ++ (c, e) :: r ->
+  exists C : frames_t exp_univ_exp exp_univ_list_prod_constr_exp, ces = C ⟦ e ⟧.
+Proof.
+  induction l; simpl; intros.
+  - subst; now exists <[cons_prod_constr_exp0 r; pair_constr_exp1 c]>.
+  - subst; edestruct IHl as [C HC]; eauto.
+    exists (<[cons_prod_constr_exp1 a]> >++ C).
+    rewrite frames_compose_law.
+    now rewrite HC; simpl.
+Defined.
+
+Lemma In_map_eq {A} (f : A -> A) x xs : In x xs -> f x = x -> In x (map f xs).
+Proof.
+  induction xs; auto; simpl.
+  intros [Heq|Hin]; auto.
+  try ltac1:(intuition congruence).
+Defined.
+
+Lemma subst_var_size σ x : size_var (σ x) = size_var x. Proof. reflexivity. Qed.
+Lemma subst_ctor_size σ x : size_ctor (σ x) = size_ctor x. Proof. reflexivity. Qed.
+Lemma subst_vars_size σ xs : size_vars (map σ xs) = size_vars xs.
+Proof.
+  induction xs as [|x xs IHxs] > [reflexivity|].
+  unfold size_vars, size_list, size_var in *; cbn in *; now rewrite IHxs.
+Qed.
+
+Fixpoint subst_exp_size σ e : size_exp (subst_exp σ e) = size_exp e
+with subst_fd_size σ e : size_fd (subst_fd σ e) = size_fd e.
+Proof.
+  - destruct e; cbn;
+    rewrite ?subst_var_size, ?subst_vars_size, ?subst_ctor_size, ?subst_exp_size, ?subst_fd_size;
+    try reflexivity.
+    + induction arms as [|[c e] ces IHces] > [reflexivity|cbn in *].
+      unfold size_list in IHces; inversion IHces as [IHces']; clear IHces.
+      now rewrite subst_exp_size, IHces'.
+    + ltac1:(repeat match goal with |- context [S (?n + ?m)] => change (S (n + m))%nat with (S n + m)%nat end).
+      do 2 f_equal; induction fds as [|fd fds IHfds] > [reflexivity|cbn in *].
+      unfold size_list in IHfds; inversion IHfds as [IHfds']; clear IHfds.
+      now rewrite subst_fd_size.
+  - destruct e as [f xs e]; cbn; now rewrite subst_vars_size, subst_exp_size.
+Qed.
+
+Definition rw_cp :
+  rewriter exp_univ_exp false (fun A C e => size e) cp_fold
+  renaming (I_renaming) _ (@I_cp_env) unit (I_S_plain (S:=unit)).
+Proof.
+  ltac1:(mk_rw;
+    try lazymatch goal with
+    (* Explain how to incrementalize substitutions *)
+    | |- ConstrDelay _ -> _ =>
+      clear; intros _; intros;
+      lazymatch goal with
+      | d : Delay _ _, H : forall _, _ |- _ =>
+        destruct d as [d Hd]; cbn in H; unshelve eapply H;
+        try lazymatch goal with |- Delay _ _ => eexists end;
+        try lazymatch goal with |- _ = _ => reflexivity end;
+        try lazymatch goal with |- I_renaming _ _ _ => exact I end
+      end
+    (* Solve easy obligations about termination *)
+    | |- MetricDecreasing -> _ =>
+      intros _; cbn; repeat match goal with |- context [let '_ := ?e in _] => destruct e end; lia
+    end).
+  - (* Case folding *)
+    intros _ R C C_ok x ces [d []] r s success failure.
+    destruct r as [ρ Hρ] eqn:Hr.
+    destruct (ρ (d x)) as [[c ys]|] eqn:Hx > [|ltac1:(cond_failure)].
+    destruct (find_arm c ces) as [e|] eqn:Hc > [|ltac1:(cond_failure)].
+    ltac1:(cond_success success).
+    specialize (success e (exist _ d I) (d x) (map (subst_arm d) ces) c (subst_exp d e)).
+    apply success; auto; unerase; split.
+    + edestruct Hρ as [D [E Hctx]]; eauto.
+    + apply find_arm_In in Hc; destruct Hc as [l [r_arms Hlr]].
+      exists (map (subst_arm d) l), (map (subst_arm d) r_arms); subst ces.
+      now rewrite !map_app.
+  - (* Projection folding *)
+    clear; intros _ R C C_ok e x y n [d []] r s success failure.
+    destruct r as [ρ Hρ] eqn:Hr.
+    destruct (ρ (d y)) as [[c ys]|] eqn:Hx > [|ltac1:(cond_failure)].
+    destruct (nth_error ys n) as [y'|] eqn:Hn > [|ltac1:(cond_failure)].
+    ltac1:(cond_success success); apply (success (subst_exp d e)
+                                                 (exist _ (fun e => one_renaming (d x) y' (d e)) I)
+                                                 (d x) (d y) n y' ys); auto; unerase.
+    + edestruct Hρ as [D [E Hctx]]; eauto.
+    + now rewrite <- subst_exp_comp.
+  - (* In case folding, the selected case arm is smaller than the case expression we started with *)
+    intros _. rewrite <- H1. clear - H; destruct H as [_ [l [r Hin]]]; subst ces; cbn.
+    ltac1:(match goal with |- (?x < S (S ?y))%nat => enough (x < y)%nat by lia end).
+    induction l as [|[c' e] ces IHces] > [cbn; ltac1:(lia)|].
+    eapply PeanoNat.Nat.lt_trans > [ltac1:(eassumption)|].
+    unfold size_list; cbn; ltac1:(lia).
+  - (* In proj folding, the subexpression is smaller than what we started with *)
+    rewrite <- H1, subst_exp_size; cbn; ltac1:(lia).
+Defined.
+
+Set Extraction Flag 2031. (* default + linear let + linear beta *)
+Recursive Extraction rw_cp. (* no fuel parameter *)
+
+Definition rw_cp_top e : result (Root:=exp_univ_exp) cp_fold (I_S_plain (S:=unit)) (erase <[]>) e.
+Proof.
+  ltac1:(replace e with (delayD ((exist _ (fun x => x) I) : (Delay I_renaming e)))
+        by (cbn; rewrite subst_exp_id; auto)).
+  ltac1:(unshelve eapply (rw_cp I);
+  try lazymatch goal with |- erased nat => refine (erase _) end;
+  try lazymatch goal with
+  | |- e_ok (erase _) => apply erase_ok
+  | |- Param _ _ => exists (fun _ => None); unerase; unfold I_cp_env; intros; congruence
+  | |- State _ _ _ => exists tt; exact I
+  | |- «_» => unerase; reflexivity
+  | |- _ = _ => reflexivity
+  end).
+Defined.
+
+(*
+Compute (rw_cp_top (
+  let x0 := 0 in
+  let x1 := 1 in
+  let x2 := 2 in
+  let x3 := 3 in
+  let x4 := 4 in
+  let x5 := 5 in
+  let x6 := 6 in
+  let c1 := 1 in
+  let c2 := 2 in
+  let c3 := 3 in
+  eCons x0 c2 [x5; x5; x1; x5; x5]
+  (eCons x2 c1 [x0; x3]
+  (eCase x0 [
+    (c1, eApp x0 [x0]);
+    (c2,
+      (eProj x4 x0 (2%nat)
+      (eProj x5 x2 (1%nat)
+      (eApp x4 [x5]))));
+    (c3, (eApp x0 [x0]))])))).
+*)

--- a/theories/L6_PCPS/Rewriting.v
+++ b/theories/L6_PCPS/Rewriting.v
@@ -1,0 +1,604 @@
+Require Import Coq.Relations.Relations.
+Require Import Coq.Setoids.Setoid.
+Require Import Coq.funind.Recdef.
+Require Import Coq.PArith.BinPos.
+Require Import Lia.
+From compcert.lib Require Import Maps.
+
+Require Import Coq.Lists.List.
+Import ListNotations.
+
+Require Import Ltac2.Ltac2.
+Import Ltac2.Notations.
+Set Default Proof Mode "Ltac2".
+
+Require Import Coq.Logic.JMeq.
+Require Import Coq.Logic.Eqdep.
+Ltac inv_ex :=
+  repeat progress match goal with
+  | H : existT ?P ?T _ = existT ?P ?T _ |- _ => apply inj_pairT2 in H
+  end.
+
+Require Export CertiCoq.L6.Frame.
+
+Set Implicit Arguments.
+
+(* -------------------- Annotations -------------------- *)
+
+Definition Rec {A} (rhs : A) : A := rhs.
+Definition BottomUp {A} (rhs : A) : A := rhs.
+
+(* -------------------- Erased values -------------------- *)
+
+(* An erased value of type [A] is a value which can only be used to construct Props.
+   We can represent erased values [x] in CPS with answer type Prop, as functions of
+   the form [fun k => k x]: *)
+Definition erased A := (A -> Prop) -> Prop.
+Class e_ok {A} (x : erased A) := erased_ok : exists (y : A), x = (fun k => k y).
+(* These two items are carried separately so that they can both be erased during extraction.
+   Bundling them together in a dependent pair type would erase to a pair type [box × box] *)
+
+(* Erasing a value *)
+Definition erase {A} : A -> erased A := fun x k => k x.
+Instance erase_ok {A} (x : A) : e_ok (erase x). Proof. exists x; reflexivity. Qed.
+
+(* Erased values can always be used to construct other erased values *)
+Definition e_map {A B} (f : A -> B) (x : erased A) : erased B := fun k => x (fun x => k (f x)).
+Instance e_map_ok {A B} (f : A -> B) (x : erased A) `{H : e_ok _ x} : e_ok (e_map f x).
+Proof. destruct H as [y Hy]; subst x; unfold e_map; now exists (f y). Qed.
+
+Definition e_map_fuse {A B C} (f : B -> C) (g : A -> B) (x : erased A) :
+  e_map f (e_map g x) = e_map (fun x => f (g x)) x.
+Proof. reflexivity. Qed.
+
+(* Only proofs can be unerased *)
+Definition recover (x : erased Prop) : Prop := x (fun x => x).
+Notation "'«' P '»'" := (recover P).
+
+(* Remove all erased operators from a goal using e_ok hypotheses *)
+Ltac unerase :=
+  repeat match goal with
+  | H : e_ok ?x |- _ => 
+    let x' := fresh x in
+    rename x into x';
+    destruct H as [x H];
+    subst x'
+  end;
+  unfold recover, e_map, erase in *.
+
+Ltac2 unerase () := ltac1:(unerase).
+Ltac2 Notation "unerase" := unerase ().
+
+(* Example *)
+Require Import Lia.
+Require Extraction.
+Module Example.
+
+Fixpoint thingy (n : erased nat) `{Hn : e_ok _ n} (m p : nat) (Hmp : «e_map (fun n => n + m = p) n») {struct m} : nat.
+Proof.
+  destruct m as [|m] > [exact p|].
+  specialize (thingy (e_map S n) _ m p); apply thingy; clear thingy.
+  ltac1:(unerase; lia).
+Defined.
+
+Print thingy.
+(* Since n and its proof are carried separately, both are erased entirely *)
+Recursive Extraction thingy.
+End Example.
+
+(* -------------------- Fixpoint combinator -------------------- *)
+
+(* Equations and Program Fixpoint use a fixpoint combinator which has the following type when
+   specialized to a particular measure [measure]:
+     [forall arg_pack, (forall arg_pack', measure arg_pack' < measure arg_pack -> P arg_pack') -> P arg_pack]
+   This requires wrapping and unwrapping [arg_pack]s. Instead we'll make
+     [forall (cost : erased nat), e_ok cost -> (forall cost', e_ok cost' -> cost' < cost -> Q cost') -> Q cost]
+   which can achieve the same thing without arg packs by setting
+     [Q := fun cost => arg1 -> ‥ -> arg_n -> cost = measure(arg1, ‥, arg_n) -> P (arg1, ‥, arg_n)].
+
+   After a function has been defined this way, unfolding all fixpoint combinators will leave behind a
+   primitive fixpoint of type
+     [forall (cost : erased nat), e_ok cost -> Accessible cost -> arg1 -> ‥ -> arg_n -> cost = measure ‥ -> P ‥]
+   that is structurally recursive on the accessibility proof [Accessible cost].
+
+   Extraction will erase [cost : erased nat], [e_ok cost], [Accessible cost], and [cost = measure ‥],
+   leaving a plain recursive function of type [arg1 -> ‥ -> arg_n -> P ‥]. *)
+Require Import Coq.Arith.Wf_nat.
+Section WellfoundedRecursion.
+
+(* Modelled after https://coq.inria.fr/library/Coq.Init.Wf.html#Acc *)
+Section AccS.
+
+  Context (A : Type) (B : A -> Prop) (R : forall x, B x -> forall y, B y -> Prop).
+
+  Inductive AccS (x : A) (Hx : B x) : Prop :=
+    AccS_intro : (forall (y : A) (Hy : B y), R Hy Hx -> @AccS y Hy) -> AccS Hx.
+
+  Definition well_foundedS := forall (x : A) (Hx : B x), AccS Hx.
+
+  Section FixS.
+
+    Context
+      (Rwf : well_foundedS)
+      (P : A -> Type)
+      (F : forall (x : A) (Hx : B x), (forall (y : A) (Hy : B y), R Hy Hx -> P y) -> P x).
+
+    Fixpoint FixS_F (x : A) (Hx : B x) (H : AccS Hx) {struct H} : P x :=
+      F (fun (y : A) (Hy : B y) (Hyx : R Hy Hx) =>
+          FixS_F (let 'AccS_intro H := H in H y Hy Hyx)).
+
+    Definition FixS (x : A) (Hx : B x) : P x := FixS_F (Rwf Hx).
+
+  End FixS.
+
+End AccS.
+
+Section FixEN.
+
+Definition enat := erased nat.
+Definition e_lt : forall x : enat, e_ok x -> forall y : enat, e_ok y -> Prop :=
+  fun n Hn m Hm => «e_map (fun n => «e_map (fun m => n < m) m») n».
+
+Lemma e_lt_wf : well_foundedS e_ok e_lt.
+Proof.
+  intros n Hn; unerase.
+  induction n as [n IHn] using Wf_nat.lt_wf_ind.
+  constructor; intros m Hm Hmn; unerase.
+  now apply IHn.
+Defined.
+
+Definition FixEN :
+  forall P : enat -> Type,
+  (forall (x : enat) (Hx : e_ok x), (forall (y : enat) (Hy : e_ok y), e_lt Hy Hx -> P y) -> P x) ->
+  forall x : enat, e_ok x -> P x
+  := FixS e_lt_wf.
+
+End FixEN.
+
+End WellfoundedRecursion.
+
+Extraction Inline FixEN FixS FixS_F.
+
+Module FixENExample.
+
+Definition plus : forall (cost : enat) `{e_ok _ cost}, forall n m : nat, «e_map (eq n) cost» -> nat.
+Proof.
+  apply (FixEN (fun cost => forall n m : nat, «e_map (eq n) cost» -> nat)).
+  intros cost Hok rec n m Hcost.
+  destruct n as [|n] > [exact m|].
+  specialize rec with (n := n).
+  specialize (rec (erase n) _).
+  apply S, rec > [|exact m|]; unfold e_lt in *; ltac1:(unerase; lia).
+Defined.
+
+End FixENExample.
+
+Print FixENExample.plus.
+Set Extraction Flag 2031. (* default + linear let + linear beta *)
+Recursive Extraction FixENExample.plus.
+
+(* -------------------- 1-hole contexts built from frames -------------------- *)
+
+(* A 1-hole context made out of frames F *)
+Inductive frames_t' {U : Set} {F : U -> U -> Set} : U -> U -> Set :=
+| frames_nil : forall {A}, frames_t' A A
+| frames_cons : forall {A B C}, F A B -> frames_t' B C -> frames_t' A C.
+Arguments frames_t' {U} F _ _.
+Notation "C '>::' f" := (frames_cons f C) (at level 50, left associativity).
+Notation "<[]>" := (frames_nil).
+Notation "<[ x ; .. ; z ]>" := (frames_cons z .. (frames_cons x frames_nil) ..).
+
+(* The 1-hole contexts you usually want *)
+Definition frames_t {U : Set} `{Frame U} : U -> U -> Set := frames_t' frame_t.
+
+(* Context application *)
+Reserved Notation "C '⟦' x '⟧'" (at level 50, no associativity).
+Fixpoint framesD {U : Set} `{Frame U} {A B : U}
+         (fs : frames_t A B) : univD A -> univD B :=
+  match fs with
+  | <[]> => fun x => x
+  | fs >:: f => fun x => fs ⟦ frameD f x ⟧
+  end
+where "C '⟦' x '⟧'" := (framesD C x).
+
+Lemma framesD_cons {U : Set} `{Frame U} {A B C : U}
+      (fs : frames_t B C) (f : frame_t A B)
+      (x : univD A)
+  : (fs >:: f) ⟦ x ⟧ = fs ⟦ frameD f x ⟧.
+Proof. reflexivity. Qed.
+
+Fixpoint frames_lift {U : Set} {F : U -> U -> Set}
+      (P : U -> Set) (Hf : forall {A B}, F A B -> P A -> P B)
+      {A B} (fs : frames_t' F A B)
+  : P A -> P B :=
+  match fs with
+  | <[]> => fun pa => pa
+  | fs >:: f => fun pa => frames_lift P (@Hf) fs (Hf f pa)
+  end.
+
+(* Context composition *)
+Reserved Notation "gs '>++' fs" (at level 50, left associativity).
+Fixpoint frames_compose {U : Set} {F : U -> U -> Set} {A B C : U}
+         (fs : frames_t' F A B) : frames_t' F B C -> frames_t' F A C :=
+  match fs with
+  | <[]> => fun gs => gs
+  | fs >:: f => fun gs => gs >++ fs >:: f
+  end
+where "gs '>++' fs" := (frames_compose fs gs).
+
+(* Laws: functor laws + injectivity *)
+
+Lemma frames_id_law {U : Set} `{Frame U} {A} (x : univD A) : <[]> ⟦ x ⟧ = x.
+Proof. auto. Qed.
+
+Lemma frames_compose_law {U : Set} `{Frame U} {A B C} :
+  forall (fs : frames_t B C) (gs : frames_t A B) (x : univD A),
+  (fs >++ gs) ⟦ x ⟧ = fs ⟦ gs ⟦ x ⟧ ⟧.
+Proof. intros fs gs; revert fs; induction gs; simpl; auto. Qed.
+
+Class Frame_inj (U : Set) `{Frame U} :=
+  frame_inj :
+    forall {A B : U} (f : frame_t A B) (x y : univD A),
+    frameD f x = frameD f y -> x = y.
+
+Lemma frames_inj {U : Set} `{Frame U} `{Frame_inj U} {A B} (fs : frames_t A B) :
+  forall (x y : univD A), fs ⟦ x ⟧ = fs ⟦ y ⟧ -> x = y.
+Proof.
+  induction fs; auto; cbn; intros x y Heq.
+  apply IHfs, (frame_inj f) in Heq; auto.
+Qed.
+
+(* Misc. lemmas (mostly about how frames_t is similar to list) *)
+
+Definition flip {U} (F : U -> U -> Set) : U -> U -> Set := fun A B => F B A.
+Fixpoint frames_rev {U : Set} {F : U -> U -> Set} {A B} (fs : frames_t' F A B) : frames_t' (flip F) B A :=
+  match fs with
+  | <[]> => <[]>
+  | fs >:: f => <[f]> >++ frames_rev fs
+  end.
+Fixpoint frames_revD {U : Set} `{Frame U} {A B : U}
+         (fs : frames_t' (flip frame_t) B A) : univD A -> univD B :=
+  match fs with
+  | <[]> => fun x => x
+  | fs >:: f => fun x => frameD f (frames_revD fs x)
+  end.
+
+Lemma frames_nil_comp {U : Set} {F : U -> U -> Set} {A B : U}
+      (fs : frames_t' F A B)
+  : <[]> >++ fs = fs.
+Proof. induction fs > [reflexivity|cbn; now rewrite IHfs]. Qed.
+
+Lemma frames_revD_comp {U : Set} `{HFrame : Frame U} {A B C : U}
+      (fs : frames_t' (flip frame_t) B A) (gs : frames_t' (flip frame_t) C B)
+      (x : univD A)
+  : frames_revD (fs >++ gs) x = frames_revD gs (frames_revD fs x).
+Proof. induction gs > [reflexivity|cbn; now rewrite IHgs]. Qed.
+
+Lemma framesD_rev {U : Set} `{Frame U} {A B : U} (fs : frames_t A B) (x : univD A)
+  : fs ⟦ x ⟧ = frames_revD (frames_rev fs) x.
+Proof.
+  induction fs > [reflexivity|cbn].
+  now rewrite frames_revD_comp, <- IHfs.
+Qed.
+
+Lemma frames_rev_assoc {U : Set} {F : U -> U -> Set} {A B C D : U}
+      (fs : frames_t' F A B) (gs : frames_t' F B C) (hs : frames_t' F C D)
+  : hs >++ (gs >++ fs) = hs >++ gs >++ fs.
+Proof. induction fs > [reflexivity|cbn; now rewrite IHfs]. Qed.
+
+Lemma frames_rev_comp {U : Set} {F : U -> U -> Set} {A B C : U}
+      (fs : frames_t' F A B) (gs : frames_t' F B C)
+  : frames_rev (gs >++ fs) = frames_rev fs >++ frames_rev gs.
+Proof.
+  induction fs; cbn.
+  - now rewrite frames_nil_comp.
+  - now rewrite IHfs, frames_rev_assoc.
+Qed.
+
+Lemma frames_rev_rev {U : Set} `{Frame U} {A B : U} (fs : frames_t A B)
+  : frames_rev (frames_rev fs) = fs.
+Proof. induction fs > [reflexivity|cbn]. now rewrite frames_rev_comp, IHfs. Qed.
+
+Fixpoint frames_any {U : Set} {F : U -> U -> Set} (P : forall {A B : U}, F A B -> Prop)
+         {A B} (fs : frames_t' F A B) : Prop :=
+  match fs with
+  | <[]> => False
+  | fs >:: f => P f \/ frames_any (@P) fs
+  end.
+
+Lemma frames_any_app
+      {U : Set} {F : U -> U -> Set} (P : forall {A B : U}, F A B -> Prop)
+      {A B C} (gs : frames_t' F B C) (fs : frames_t' F A B)
+  : frames_any (@P) (gs >++ fs) <-> frames_any (@P) gs \/ frames_any (@P) fs.
+Proof. induction fs > [cbn; ltac1:(tauto)|cbn]. rewrite IHfs; ltac1:(tauto). Qed.
+
+Lemma frames_any_cons
+      {U : Set} {F : U -> U -> Set} (P : forall {A B : U}, F A B -> Prop)
+      {A B C} (fs : frames_t' F B C) (f : F A B)
+  : frames_any (@P) (fs >:: f) <-> frames_any (@P) fs \/ P f.
+Proof. unfold frames_any; ltac1:(tauto). Qed.
+
+Fixpoint frames_len {U : Set} {F : U -> U -> Set} {A B} (fs : frames_t' F A B) : nat :=
+  match fs with
+  | <[]> => O
+  | fs >:: f => S (frames_len fs)
+  end.
+
+Lemma frames_len_compose {U : Set} {F : U -> U -> Set} {A B C}
+      (fs : frames_t' F A B) (gs : frames_t' F B C) :
+  frames_len (gs >++ fs) = frames_len fs + frames_len gs.
+Proof. induction fs as [|A' AB B' f fs IHfs] > [reflexivity|cbn]. now rewrite IHfs. Qed.
+
+(* Useful in situations where [destruct] struggles with dependencies *)
+Lemma frames_split' {U : Set} {F : U -> U -> Set} {A B} (fs : frames_t' F A B) :
+  (exists AB (g : F A AB) (gs : frames_t' F AB B), fs = gs >:: g) \/
+  (A = B /\ JMeq fs (<[]> : frames_t' F A A) /\ frames_len fs = 0%nat).
+Proof. destruct fs as [| A' AB B' f fs] > [now right|left; now do 3 eexists]. Qed.
+
+(* Like frames_split', but peels off frames from the left instead of from the right *)
+Lemma frames_split {U : Set} {F : U -> U -> Set} {A B} (fs : frames_t' F A B) :
+  (exists AB (g : F AB B) (gs : frames_t' F A AB), fs = <[g]> >++ gs) \/ (frames_len fs = O).
+Proof.
+  induction fs as [| A' AB B' f fs IHfs] > [now right|left].
+  destruct IHfs as [[AB' [g [gs Hgs]]] | Hnil].
+  - subst. do 2 eexists; exists (gs >:: f); reflexivity.
+  - destruct fs; simpl in Hnil; inversion Hnil. do 2 eexists; exists <[]>; reflexivity.
+Qed.
+
+(* Well-founded induction on the length of the context *)
+Lemma frames_len_ind (U : Set) (F : U -> U -> Set)
+      (P : forall {A B}, frames_t' F A B -> Prop)
+      (Hlt : forall {A B} (fs : frames_t' F A B),
+        (forall {C D} (gs : frames_t' F C D), frames_len gs < frames_len fs -> P gs) ->
+        P fs)
+      A B (fs : frames_t' F A B)
+  : P fs.
+Proof.
+  remember (frames_len fs) as n eqn:Hlen.
+  ltac1:(generalize dependent B; generalize dependent A).
+  induction n as [n IHn] using lt_wf_ind; intros A B fs Hlen.
+  apply Hlt; intros C D gs Hlt_gs; eapply IHn > [|reflexivity]; ltac1:(lia).
+Qed.
+
+(* [frames_t] is a snoc-list of frames; this is an induction principle for reasoning about
+   them as if they were cons-lists. *)
+Lemma frames_rev_ind (U : Set) (F : U -> U -> Set)
+      (P : forall {A B}, frames_t' F A B -> Prop)
+      (Hnil : forall {A}, P (<[]> : frames_t' F A A))
+      (Hcons : forall {A B C} (f : F B C) (fs : frames_t' F A B), P fs -> P (<[f]> >++ fs))
+      A B (fs : frames_t' F A B)
+  : P fs.
+Proof.
+  induction fs as [A B fs IHfs] using frames_len_ind.
+  destruct (frames_split fs) as [[AB [f [fs' Hfs']]] | Hfs_nil] > [subst fs|].
+  - apply Hcons, IHfs; rewrite frames_len_compose; cbn; ltac1:(lia).
+  - destruct fs > [|now cbn in Hfs_nil]; apply Hnil.
+Qed.
+
+(* -------------------- Rewriters -------------------- *)
+Section Rewriters.
+
+Context
+  (* Types the rewriter will encounter + type of 1-hole contexts *)
+  (U : Set) `{HFrame : Frame U}
+  (* The type of trees being rewritten *)
+  (Root : U).
+
+(* State variables, parameters, and delayed computations *)
+Section Strategies.
+
+Context
+  (D : Set) (I_D : forall (A : U), univD A -> D -> Prop)
+  (R : Set) (I_R : forall (A : U), frames_t A Root -> R -> Prop)
+  (S : Set) (I_S : forall (A : U), frames_t A Root -> univD A -> S -> Prop).
+
+Definition Delay {A} (e : univD A) : Set := {d | I_D A e d}.
+Definition Param {A} (C : erased (frames_t A Root)) : Set :=
+  {r | «e_map (fun C => I_R C r) C»}.
+Definition State {A} (C : erased (frames_t A Root)) (e : univD A) : Set :=
+  {s | «e_map (fun C => I_S C e s) C»}.
+
+Class Delayed := {
+  delayD : forall {A} (e : univD A), Delay e -> univD A;
+  delay_id : forall {A} (e : univD A), Delay e;
+  delay_id_law : forall {A} (e : univD A), delayD (delay_id e) = e }.
+
+Class Preserves_R :=
+  preserve_R :
+    forall {A B : U} (fs : erased (frames_t B Root)) `{e_ok _ fs} (f : frame_t A B),
+    Param fs -> Param (e_map (fun fs => fs >:: f) fs).
+
+Class Preserves_S_up :=
+  preserve_S_up :
+    forall {A B : U} (fs : erased (frames_t B Root)) `{e_ok _ fs} (f : frame_t A B) (x : univD A),
+    State (e_map (fun fs => fs >:: f) fs) x -> State fs (frameD f x).
+
+Class Preserves_S_dn :=
+  preserve_S_dn :
+    forall {A B : U} (fs : erased (frames_t B Root)) `{e_ok _ fs} (f : frame_t A B) (x : univD A),
+    State fs (frameD f x) -> State (e_map (fun fs => fs >:: f) fs) x.
+
+Extraction Inline delayD delay_id preserve_R preserve_S_up preserve_S_dn.
+
+End Strategies.
+
+(* Handy instances *)
+
+(* Structures with no invariants *)
+
+Definition I_D_plain (D : Set) (A : U) (_ : univD A) (_ : D) : Prop := True.
+Definition id_Delay := @Delay unit (@I_D_plain unit).
+
+Global Instance Delayed_id_Delay : Delayed (@I_D_plain unit).
+Proof.
+  ltac1:(unshelve econstructor).
+  - intros A x _; exact x.
+  - intros; exists tt; exact I.
+  - reflexivity.
+Defined.
+
+Definition I_R_plain (R : Set) (A : U) (C : frames_t A Root) (_ : R) : Prop := True.
+Definition I_S_plain (S : Set) (A : U) (C : frames_t A Root) (_ : univD A) (_ : S) : Prop := True.
+
+Global Instance Preserves_R_plain (R : Set) : Preserves_R (@I_R_plain R).
+Proof. unfold Preserves_R; intros; assumption. Defined.
+
+Global Instance Preserves_S_up_plain (S : Set) : Preserves_S_up (@I_S_plain S).
+Proof. unfold Preserves_S_up; intros; assumption. Defined.
+
+Global Instance Preserves_S_dn_plain (S : Set) : Preserves_S_dn (@I_S_plain S).
+Proof. unfold Preserves_S_dn; intros; assumption. Defined.
+
+Extraction Inline Delayed_id_Delay Preserves_R_plain Preserves_S_up_plain Preserves_S_dn_plain.
+
+(* Composing two parameters *)
+Section R_prod.
+
+Context
+  (R1 R2 : Set)
+  (I_R1 : forall A, frames_t A Root -> R1 -> Prop) 
+  (I_R2 : forall A, frames_t A Root -> R2 -> Prop).
+
+Definition I_R_prod A (C : frames_t A Root) : R1 * R2 -> Prop :=
+  fun '(r1, r2) => I_R1 C r1 /\ I_R2 C r2.
+
+Global Instance Preserves_R_prod
+       `{H1 : @Preserves_R _ (@I_R1)}
+       `{H2 : @Preserves_R _ (@I_R2)} :
+  Preserves_R I_R_prod.
+Proof.
+  unfold I_R_prod; intros A B C C_ok f [[r1 r2] Hr12].
+  assert (Hr1 : «e_map (fun C => I_R1 _ C r1) C»). { unerase; now destruct Hr12. }
+  assert (Hr2 : «e_map (fun C => I_R2 _ C r2) C»). { unerase; now destruct Hr12. }
+  pattern r1 in Hr1; pattern r2 in Hr2. apply exist in Hr1; apply exist in Hr2. clear Hr12 r1 r2.
+  ltac1:(unshelve eapply preserve_R with (f := f) in Hr1); try assumption.
+  ltac1:(unshelve eapply preserve_R with (f := f) in Hr2); try assumption.
+  destruct Hr1 as [r1 Hr1], Hr2 as [r2 Hr2]; exists (r1, r2).
+  unerase; auto.
+Defined.
+
+Extraction Inline Preserves_R_prod.
+
+End R_prod.
+
+(* Composing two states *)
+Section S_prod.
+
+Context
+  (S1 S2 : Set)
+  (I_S1 : forall A, frames_t A Root -> univD A -> S1 -> Prop) 
+  (I_S2 : forall A, frames_t A Root -> univD A -> S2 -> Prop).
+
+Definition I_S_prod A (C : frames_t A Root) (e : univD A) : S1 * S2 -> Prop :=
+  fun '(s1, s2) => I_S1 C e s1 /\ I_S2 C e s2.
+
+Global Instance Preserves_S_up_prod
+         `{H1 : @Preserves_S_up _ (@I_S1)}
+         `{H2 : @Preserves_S_up _ (@I_S2)} :
+  Preserves_S_up I_S_prod.
+Proof.
+  unfold I_S_prod; intros A B C C_ok f x [[s1 s2] Hs12].
+  assert (Hs1 : «e_map (fun C => I_S1 _ (C >:: f) x s1) C»). { unerase; now destruct Hs12. }
+  assert (Hs2 : «e_map (fun C => I_S2 _ (C >:: f) x s2) C»). { unerase; now destruct Hs12. }
+  pattern s1 in Hs1; pattern s2 in Hs2; apply exist in Hs1; apply exist in Hs2; clear Hs12 s1 s2.
+  ltac1:(unshelve eapply preserve_S_up with (f := f) in Hs1); try assumption.
+  ltac1:(unshelve eapply preserve_S_up with (f := f) in Hs2); try assumption.
+  destruct Hs1 as [s1 Hs1], Hs2 as [s2 Hs2]; exists (s1, s2); unerase; auto.
+Defined.
+
+Global Instance Preserves_S_dn_prod
+         `{H1 : @Preserves_S_dn _ (@I_S1)}
+         `{H2 : @Preserves_S_dn _ (@I_S2)} :
+  Preserves_S_dn I_S_prod.
+Proof.
+  unfold I_S_prod; intros A B C C_ok f x [[s1 s2] Hs12].
+  assert (Hs1 : «e_map (fun C => I_S1 _ C (frameD f x) s1) C»). { unerase; now destruct Hs12. }
+  assert (Hs2 : «e_map (fun C => I_S2 _ C (frameD f x) s2) C»). { unerase; now destruct Hs12. }
+  pattern s1 in Hs1; pattern s2 in Hs2; apply exist in Hs1; apply exist in Hs2; clear Hs12 s1 s2.
+  ltac1:(unshelve eapply preserve_S_dn with (f := f) in Hs1); try assumption.
+  ltac1:(unshelve eapply preserve_S_dn with (f := f) in Hs2); try assumption.
+  destruct Hs1 as [s1 Hs1], Hs2 as [s2 Hs2]; exists (s1, s2); unerase; auto.
+Defined.
+
+Extraction Inline Preserves_S_up_prod Preserves_S_dn_prod.
+
+End S_prod.
+
+Section FuelAndMetric.
+
+Definition Fuel (fueled : bool) := if fueled then positive else True.
+
+Definition is_empty (fueled : bool) : Fuel fueled -> bool :=
+  match fueled with
+  | true => fun fuel => match fuel with xH => true | _ => false end
+  | false => fun 'I => false
+  end.
+
+Definition fuel_dec (fueled : bool) : Fuel fueled -> Fuel fueled :=
+  match fueled with
+  | true => fun fuel => Pos.pred fuel
+  | false => fun fuel => fuel
+  end.
+
+Definition lots_of_fuel : positive := (1~1~1~1~1~1~1~1~1~1~1~1~1~1~1~1~1~1~1)%positive.
+
+Extraction Inline is_empty fuel_dec lots_of_fuel.
+
+Definition Metric (fueled : bool) :=
+  if fueled then unit
+  else forall A, frames_t A Root -> univD A -> nat.
+
+Definition run_metric (fueled : bool) (metric : Metric fueled)
+           (fuel : Fuel fueled) A (C : frames_t A Root) (e : univD A) : nat :=
+  match fueled return Fuel fueled -> Metric fueled -> nat with
+  | true => fun fuel 'tt => Pos.to_nat fuel
+  | false => fun fuel metric => metric A C e
+  end fuel metric.
+
+End FuelAndMetric.
+
+(* The type of the rewriter *)
+Section Rewriter.
+
+Context
+  (* Fueled rewriters use [positive] as fuel parameter *)
+  (fueled : bool)
+  (Fuel := Fuel fueled)
+  (metric : Metric fueled)
+  (run_metric := run_metric fueled metric)
+  (* One rewriting step *)
+  (Rstep : relation (univD Root))
+  (* Delayed computation, parameter, and state variable *)
+  (D : Set) (I_D : forall (A : U), univD A -> D -> Prop)
+  (R : Set) (I_R : forall (A : U), frames_t A Root -> R -> Prop)
+  (S : Set) (I_S : forall (A : U), frames_t A Root -> univD A -> S -> Prop)
+  `{HDelay : Delayed _ I_D}.
+
+(* The result returned by a rewriter when called with context C and exp e *)
+Record result A (C : erased (frames_t A Root)) (e : univD A) : Set := mk_result {
+  resTree : univD A;
+  resState : State I_S C resTree;
+  resProof : «e_map (fun C => clos_refl_trans _ Rstep (C ⟦ e ⟧) (C ⟦ resTree ⟧)) C» }.
+
+Definition rw_for (fuel : Fuel) A (C : erased (frames_t A Root)) (e : univD A) :=
+  forall n `{e_ok _ n} (r : Param I_R C) (s : State I_S C e),
+  «e_map (fun n => «e_map (fun C => n = run_metric fuel C e) C») n» ->
+  result C e.
+
+Definition rewriter' :=
+  forall (fuel : Fuel) A (C : erased (frames_t A Root)) `{e_ok _ C} (e : univD A) (d : Delay I_D e),
+  rw_for fuel C (delayD d).
+
+Definition res_chain A (C : erased (frames_t A Root)) `{e_ok _ C} (e : univD A) (m : result C e)
+           (k : forall e (s : State I_S C e), result C e) : result C e.
+Proof.
+  destruct m as [e' s' Hrel1]; cbn in k.
+  specialize (k e' s'); destruct k as [e'' s'' Hrel2].
+  econstructor > [exact s''|unerase; eapply rt_trans; eauto].
+Defined.
+
+Extraction Inline res_chain.
+
+End Rewriter.
+
+End Rewriters.

--- a/theories/L6_PCPS/cps_proto.v
+++ b/theories/L6_PCPS/cps_proto.v
@@ -1,0 +1,657 @@
+(* The stack-of-frames one-hole contexts, with the right indices, are isomorphic to 
+   [cps.exp_ctx] and [cps.fundefs_ctx] *)
+
+From Coq Require Import ZArith.ZArith Lists.List Sets.Ensembles Strings.String.
+Require Import Lia.
+Import ListNotations.
+
+From CertiCoq.L6 Require Import
+     Prototype cps cps_util ctx
+     identifiers Ensembles_util.
+
+From MetaCoq Require Import Template.All.
+
+From CertiCoq.L6 Require Import PrototypeGenFrame cps.
+
+Run TemplateProgram (mk_Frame_ops
+  "exp" exp [var; fun_tag; ctor_tag; prim; N; list var]).
+Print exp_univ.
+Print exp_univD.
+
+Instance Frame_exp : Frame exp_univ := exp_Frame_ops.
+Instance AuxData_exp : AuxData exp_univ := exp_aux_data.
+
+Print exp_frame_t.
+Print exp_frameD.
+Print exp_Frame_ops.
+
+Open Scope list_scope.
+
+(* The type of one-hole contexts *)
+Definition exp_c : exp_univ -> exp_univ -> Set := frames_t.
+
+(* cps.exp_ctx -> exp_c _ _ *)
+
+Definition c_of_ces (ces : list (cps.ctor_tag * cps.exp)) :
+  exp_c exp_univ_list_prod_ctor_tag_exp exp_univ_list_prod_ctor_tag_exp :=
+  fold_right
+    (fun '(c, e) frames =>
+      <[cons_prod_ctor_tag_exp1 (c, e)]> >++ frames)
+    <[]>
+    ces.
+
+Definition c_of_ces_ctx' c_of_exp_ctx (ces1 : list (cps.ctor_tag * cps.exp)) (c : cps.ctor_tag)
+           (C : exp_ctx) (ces2 : list (cps.ctor_tag * cps.exp))
+  : exp_c exp_univ_exp exp_univ_list_prod_ctor_tag_exp :=
+  c_of_ces ces1
+    >++ <[cons_prod_ctor_tag_exp0 ces2; pair_ctor_tag_exp1 c]>
+    >++ c_of_exp_ctx C.
+
+Fixpoint c_of_exp_ctx (C : exp_ctx) : exp_c exp_univ_exp exp_univ_exp
+with c_of_fundefs_ctx (C : fundefs_ctx) : exp_c exp_univ_exp exp_univ_fundefs.
+Proof.
+  - refine (
+      match C with
+      | Hole_c => <[]>
+      | Econstr_c x c ys C => <[Econstr3 x c ys]> >++ c_of_exp_ctx C
+      | Eproj_c x c n y C => <[Eproj4 x c n y]> >++ c_of_exp_ctx C
+      | Eprim_c x p ys C => <[Eprim3 x p ys]> >++ c_of_exp_ctx C
+      | Eletapp_c x f ft ys C => <[Eletapp4 x f ft ys]> >++ c_of_exp_ctx C
+      | Ecase_c x ces1 c C ces2 => <[Ecase1 x]> >++ c_of_ces_ctx' c_of_exp_ctx ces1 c C ces2
+      | Efun1_c fds C => <[Efun1 fds]> >++ c_of_exp_ctx C
+      | Efun2_c C e => <[Efun0 e]> >++ c_of_fundefs_ctx C
+      end).
+  - refine (
+      match C with
+      | Fcons1_c f ft xs C fds => <[Fcons3 f ft xs fds]> >++ c_of_exp_ctx C
+      | Fcons2_c f ft xs e C => <[Fcons4 f ft xs e]> >++ c_of_fundefs_ctx C
+      end).
+Defined.
+
+Definition c_of_ces_ctx := c_of_ces_ctx' c_of_exp_ctx.
+
+(* exp_c _ _ -> cps.exp_ctx: directly writing a recursive function on exp_c is annoying because
+   of the indices. Instead map each frame to a "slice" of an exp_ctx represented as a function 
+   ctx |-> slice + ctx. Then all the functions can be composed together and initialized with 
+   the empty context. *)
+
+Definition univ_rep (A : exp_univ) : Set :=
+  match A with
+  | exp_univ_prod_ctor_tag_exp => cps.ctor_tag * exp_ctx
+  | exp_univ_list_prod_ctor_tag_exp =>
+    list (cps.ctor_tag * cps.exp) * cps.ctor_tag * exp_ctx * list (cps.ctor_tag * cps.exp)
+  | exp_univ_fundefs => fundefs_ctx
+  | exp_univ_exp => exp_ctx
+  | exp_univ_var => False
+  | exp_univ_fun_tag => False
+  | exp_univ_ctor_tag => False
+  | exp_univ_prim => False
+  | exp_univ_N => False
+  | exp_univ_list_var => False
+  end.
+
+Definition exp_frame_rep {A B} (f : exp_frame_t A B) : univ_rep A -> univ_rep B.
+Proof.
+  destruct f eqn:Hf; cbn;
+  try lazymatch goal with |- False -> _ => inversion 1 end.
+  - exact (fun ctx => (c, ctx)).
+  - exact (fun '(c, e) => ([], c, e, l)).
+  - exact (fun '(ces1, c, e, ces2) => (p :: ces1, c, e, ces2)).
+  - exact (fun ctx => Fcons1_c v f0 l ctx f1).
+  - exact (fun ctx => Fcons2_c v f0 l e ctx).
+  - exact (fun ctx => Econstr_c v c l ctx).
+  - exact (fun '(ces1, c, e, ces2) => Ecase_c v ces1 c e ces2).
+  - exact (fun ctx => Eproj_c v c n v0 ctx).
+  - exact (fun ctx => Eletapp_c v v0 f0 l ctx).
+  - exact (fun ctx => Efun2_c ctx e).
+  - exact (fun ctx => Efun1_c f0 ctx).
+  - exact (fun ctx => Eprim_c v p l ctx).
+Defined.
+
+Fixpoint exp_c_rep {A B} (C : exp_c A B) : univ_rep A -> univ_rep B :=
+  match C with
+  | <[]> => fun x => x
+  | C >:: f => fun x => exp_c_rep C (exp_frame_rep f x)
+  end.
+
+Definition exp_ctx_of_c (C : exp_c exp_univ_exp exp_univ_exp) : exp_ctx :=
+  exp_c_rep C Hole_c.
+
+Definition fundefs_ctx_of_c (C : exp_c exp_univ_exp exp_univ_fundefs) : fundefs_ctx :=
+  exp_c_rep C Hole_c.
+
+Lemma exp_c_rep_compose {A B C} (fs : exp_c A B) (gs : exp_c B C) x :
+  exp_c_rep (gs >++ fs) x = exp_c_rep gs (exp_c_rep fs x).
+Proof. induction fs as [ |A' AB B' f fs IHfs]; [reflexivity|cbn; now rewrite IHfs]. Qed.
+
+(* exp_ctx -> exp_c -> exp_ctx *)
+
+Lemma fold_right_cons {A B} (f : A -> B -> B) z x xs :
+  fold_right f z (x :: xs) = f x (fold_right f z xs).
+Proof. reflexivity. Qed.
+
+Lemma ces_ctx_c_ces_ctx : forall ces ces1 c C ces2,
+  exp_c_rep (c_of_ces ces) (ces1, c, C, ces2) = (ces ++ ces1, c, C, ces2).
+Proof.
+  clear; induction ces as [| [c e] ces IHces]; [reflexivity|]; intros ces1 ctr C ces2.
+  unfold c_of_ces; rewrite fold_right_cons, exp_c_rep_compose.
+  now rewrite IHces.
+Qed.
+
+Fixpoint exp_ctx_c_exp_ctx (C : exp_ctx) : exp_ctx_of_c (c_of_exp_ctx C) = C
+with fundefs_ctx_c_fundefs_ctx (C : fundefs_ctx) : fundefs_ctx_of_c (c_of_fundefs_ctx C) = C.
+Proof.
+  all: unfold exp_ctx_of_c, fundefs_ctx_of_c in *;
+    destruct C; simpl;
+    try reflexivity;
+    rewrite ?exp_c_rep_compose;
+    try solve [(rewrite exp_ctx_c_exp_ctx + rewrite fundefs_ctx_c_fundefs_ctx); reflexivity].
+  unfold c_of_ces_ctx'.
+  rewrite !exp_c_rep_compose; cbn.
+  now rewrite ces_ctx_c_ces_ctx, app_nil_r, exp_ctx_c_exp_ctx.
+Qed.
+
+(* exp_c -> exp_ctx -> exp_c: because exp_c is 'inside-out', destructing normally
+   on (C : exp_c _ _) yields subcases like
+     c_of_foo (foo_of_c (C >:: f)) = C
+     <=> c_of_foo (exp_c_rep C (exp_frame_rep f Hole_c)) = C
+   which isn't helpful because c_of_foo is stuck: exp_c_rep won't spit out a constructor
+   until its consumed the rest of C.
+
+   Fix: split C into <[]> and <[g]> >++ gs cases and use exp_c_rep_compose:
+     c_of_foo (foo_of_c (<[f]> >++ C)) = C
+     <=> c_of_foo (exp_c_rep (<[f]> >++ C Hole_c)) = C
+     <=> c_of_foo (exp_c_rep <[f]> (exp_c_rep C Hole_c)) = C
+     <=> c_of_foo (exp_frame_rep f (exp_c_rep C Hole_c)) = C
+   [exp_frame_rep f] will expose constructors for c_of_foo. *)
+
+Definition c_ctx_c_stmt {A B} : exp_c A B -> Prop :=
+  match A, B with
+  | exp_univ_exp, exp_univ_exp => fun C => c_of_exp_ctx (exp_ctx_of_c C) = C
+  | exp_univ_exp, exp_univ_fundefs => fun C => c_of_fundefs_ctx (fundefs_ctx_of_c C) = C
+  | exp_univ_exp, exp_univ_prod_ctor_tag_exp => fun C =>
+    let '(c, ctx) := exp_c_rep C Hole_c in
+    <[pair_ctor_tag_exp1 c]> >++ c_of_exp_ctx ctx = C
+  | exp_univ_exp, exp_univ_list_prod_ctor_tag_exp => fun C =>
+    let '(ces1, c, ctx, ces2) := exp_c_rep C Hole_c in
+    c_of_ces_ctx ces1 c ctx ces2 = C
+  | _, _ => fun _ => True
+  end.
+
+Lemma c_ctx_c {A B} (C : exp_c A B) : c_ctx_c_stmt C.
+Proof.
+  induction C as [|A AB B g gs IHgs] using frames_rev_ind.
+  - destruct A; try exact I; reflexivity.
+  - destruct g, A; try exact I;
+      cbn; unfold exp_ctx_of_c, fundefs_ctx_of_c;
+      rewrite ?exp_c_rep_compose; cbn;
+      try match goal with
+      | |- context [match ?e with end] =>
+        let H := fresh "H" in assert (H : False) by exact e; inversion H
+      end;
+      match goal with |- context [exp_c_rep gs Hole_c] =>
+        match type of gs with
+        | frames_t' _ ?hole ?root =>
+          unfold c_ctx_c_stmt in IHgs;
+          unfold exp_ctx_of_c, fundefs_ctx_of_c in IHgs
+        end
+      end;
+      try solve [erewrite IHgs; eauto; rewrite frames_len_compose; simpl; lia].
+    + destruct (exp_c_rep gs Hole_c) as [c e] eqn:Hce.
+      unfold c_of_ces_ctx, c_of_ces_ctx'.
+      now rewrite <- IHgs, frames_rev_assoc.
+    + destruct (exp_c_rep gs Hole_c) as [[[ces1 c] e] ces2] eqn:Hces12.
+      destruct p as [c' e']; simpl.
+      unfold c_of_ces_ctx, c_of_ces_ctx' in *.
+      now rewrite <- IHgs, frames_rev_assoc.
+    + destruct (exp_c_rep gs Hole_c) as [[[f ft] xs] ctx] eqn:Hces12.
+      simpl; unfold c_of_ces_ctx, c_of_ces_ctx' in *.
+      now erewrite <- IHgs, frames_rev_assoc.
+Qed.
+
+Corollary c_exp_ctx_c (C : exp_c exp_univ_exp exp_univ_exp) :
+  c_of_exp_ctx (exp_ctx_of_c C) = C.
+Proof. apply (c_ctx_c C). Qed.
+
+Corollary c_fundefs_ctx_c (C : exp_c exp_univ_exp exp_univ_fundefs) :
+  c_of_fundefs_ctx (fundefs_ctx_of_c C) = C.
+Proof. apply (c_ctx_c C). Qed.
+
+Ltac normalize_roundtrips :=
+  try rewrite exp_c_rep_compose; simpl;
+  try rewrite c_exp_ctx_c in *;
+  try rewrite c_fundefs_ctx_c in *;
+  try rewrite exp_ctx_c_exp_ctx in *;
+  try rewrite fundefs_ctx_c_fundefs_ctx in *.
+
+(* ---------- package all the above together ---------- *)
+
+Class Iso A B := {
+  isoAofB : B -> A;
+  isoBofA : A -> B;
+  isoABA : forall x, isoAofB (isoBofA x) = x;
+  isoBAB : forall x, isoBofA (isoAofB x) = x }.
+
+Notation "'![' e ']'" := (isoBofA e).
+Notation "'[' e ']!'" := (isoAofB e).
+
+Instance Iso_exp_c_exp_ctx : Iso (exp_c exp_univ_exp exp_univ_exp) exp_ctx := {
+  isoAofB := c_of_exp_ctx;
+  isoBofA := exp_ctx_of_c;
+  isoABA := c_exp_ctx_c;
+  isoBAB := exp_ctx_c_exp_ctx }.
+
+Instance Iso_fundefs_c_fundefs_ctx : Iso (exp_c exp_univ_exp exp_univ_fundefs) fundefs_ctx := {
+  isoAofB := c_of_fundefs_ctx;
+  isoBofA := fundefs_ctx_of_c;
+  isoABA := c_fundefs_ctx_c;
+  isoBAB := fundefs_ctx_c_fundefs_ctx }.
+
+Lemma iso_proof {A B} `{Iso A B} (P : A -> Prop) (Hxy : forall y, P [y]!) : forall x, P x.
+Proof.
+  intros x; specialize (Hxy ![x]).
+  now rewrite isoABA in Hxy.
+Qed.
+
+Ltac iso x := pattern x; revert x; apply iso_proof; intros x.
+
+Lemma iso_BofA_inj {A B} `{Iso A B} x y : ![x] = ![y] -> x = y.
+Proof.
+  intros Heq; apply f_equal with (f := fun x => [x]!) in Heq.
+  now repeat rewrite isoABA in Heq.
+Qed.
+
+Lemma iso_AofB_inj {A B} `{Iso A B} x y : [x]! = [y]! -> x = y.
+Proof.
+  intros Heq; apply f_equal with (f := fun x => ![x]) in Heq.
+  now repeat rewrite isoBAB in Heq.
+Qed.
+
+(* ---------- exp_c application agrees with app_ctx_f + app_f_ctx_f ---------- *)
+
+Fixpoint app_exp_ctx_eq (C : exp_ctx) e {struct C} :
+  C |[ e ]| = ([C]! : exp_c exp_univ_exp exp_univ_exp) ⟦ e ⟧
+with app_fundefs_ctx_eq (C : fundefs_ctx) e {struct C} :
+  app_f_ctx_f C e = ([C]! : exp_c exp_univ_exp exp_univ_fundefs) ⟦ e ⟧.
+Proof.
+  all: destruct C; simpl;
+    try lazymatch goal with
+    | |- context [(?fs >++ ?gs) ⟦ _ ⟧] =>
+      rewrite (@frames_compose_law exp_univ Frame_exp _ _ _ fs gs)
+    end; simpl; normalize_roundtrips; try reflexivity;
+    try solve [(rewrite <- app_exp_ctx_eq + rewrite <- app_fundefs_ctx_eq); reflexivity].
+  - f_equal.
+    unfold c_of_ces_ctx'.
+    repeat rewrite frames_compose_law.
+    rewrite <- app_exp_ctx_eq.
+    simpl.
+    assert (Harms : forall ces1 ces2, c_of_ces ces1 ⟦ ces2 ⟧ = ces1 ++ ces2). {
+      clear; induction ces1 as [| [c e] ces1 IHces]; intros ces2; [reflexivity|].
+      unfold c_of_ces; now rewrite fold_right_cons, frames_compose_law, IHces. }
+    now rewrite Harms.
+Qed.
+
+Local Ltac mk_corollary parent :=
+  apply iso_BofA_inj; simpl; repeat normalize_roundtrips;
+  symmetry; apply parent.
+
+Corollary app_exp_c_eq (C : exp_c exp_univ_exp exp_univ_exp) :
+  forall e, C ⟦ e ⟧ = ![C] |[ e ]|.
+Proof. iso C; intros e; now rewrite app_exp_ctx_eq, isoABA. Qed.
+
+Corollary app_f_exp_c_eq (C : exp_c exp_univ_exp exp_univ_fundefs) :
+  forall e, C ⟦ e ⟧ = app_f_ctx_f ![C] e.
+Proof. iso C; intros e. now rewrite app_fundefs_ctx_eq, isoABA. Qed.
+
+(* ---------- exp_c composition agrees with comp_ctx_f + comp_f_ctx_f ---------- *)
+
+Local Ltac fold_exp_c_reps :=
+  lazymatch goal with
+  | |- context [exp_c_rep ?C Hole_c] =>
+    lazymatch type of C with
+    | exp_c exp_univ_exp exp_univ_exp => change (exp_c_rep C Hole_c) with (exp_ctx_of_c C)
+    end
+  | H : context [exp_c_rep ?C Hole_c] |- _ =>
+    lazymatch type of C with
+    | exp_c exp_univ_exp exp_univ_exp => change (exp_c_rep C Hole_c) with (exp_ctx_of_c C) in H
+    end
+  end.
+
+Fixpoint comp_exp_ctx_eq C D {struct C} : comp_ctx_f C D = ![[C]! >++ [D]!]
+with comp_fundefs_ctx_eq C D {struct C} : comp_f_ctx_f C D = ![[C]! >++ [D]!].
+Proof.
+  all: simpl in *; destruct C; simpl; unfold exp_ctx_of_c, fundefs_ctx_of_c;
+    repeat rewrite exp_c_rep_compose; simpl;
+    fold_exp_c_reps; normalize_roundtrips; f_equal; try solve
+    [reflexivity
+    |match goal with
+      | |- _ ?C ?D = _ =>
+        let use_IH IH1 IH2 :=
+          specialize (IH1 C D); clear IH2;
+          unfold exp_ctx_of_c, fundefs_ctx_of_c in IH1;
+          rewrite exp_c_rep_compose in IH1
+        in
+        use_IH comp_exp_ctx_eq comp_fundefs_ctx_eq + use_IH comp_fundefs_ctx_eq comp_exp_ctx_eq
+     end; unfold exp_ctx_of_c in *;
+     fold_exp_c_reps; normalize_roundtrips; assumption].
+  unfold c_of_ces_ctx'.
+  repeat rewrite exp_c_rep_compose; simpl.
+  rewrite ces_ctx_c_ces_ctx, app_nil_r; normalize_roundtrips; f_equal.
+  specialize (comp_exp_ctx_eq C D); unfold exp_ctx_of_c in comp_exp_ctx_eq.
+  rewrite exp_c_rep_compose in comp_exp_ctx_eq; fold_exp_c_reps; now normalize_roundtrips.
+Qed.
+
+Corollary comp_exp_c_eq C D : C >++ D = [comp_ctx_f ![C] ![D]]!.
+Proof. revert D; iso C; intros D; iso D; mk_corollary comp_exp_ctx_eq. Qed.
+
+Corollary comp_fundefs_c_eq C D : C >++ D = [comp_f_ctx_f ![C] ![D]]!.
+Proof. revert D; iso C; intros D; iso D; mk_corollary comp_fundefs_ctx_eq. Qed.
+
+(* ---------- Facts about used variables ---------- *)
+
+Fixpoint used_ces (ces : list (ctor_tag * exp)) : Ensemble cps.var :=
+  match ces with
+  | [] => Empty_set _
+  | (_, e) :: ces => used_vars e :|: used_ces ces
+  end.
+
+Definition used {A} : univD A -> Ensemble cps.var :=
+  match A with
+  | exp_univ_prod_ctor_tag_exp => fun '(_, e) => used_vars e
+  | exp_univ_list_prod_ctor_tag_exp => used_ces
+  | exp_univ_fundefs => fun fds => used_vars_fundefs fds
+  | exp_univ_exp => fun e => used_vars e
+  | exp_univ_var => fun x => [set x]
+  | exp_univ_fun_tag => fun _ => Empty_set _
+  | exp_univ_ctor_tag => fun _ => Empty_set _
+  | exp_univ_prim => fun _ => Empty_set _
+  | exp_univ_N => fun _ =>  Empty_set _
+  | exp_univ_list_var => fun xs => FromList xs
+  end.
+
+(*
+(* TODO: use a prettier definition in terms of greatest lower bound of all [frameD f x]s.
+   Then show that for every hole type can find x1, x2 such that
+     glb_x (frameD f x) = frameD f x1 ∩ frameD f x2 *)
+Definition used_c {A B} (C : exp_c A B) : Ensemble cps.var :=
+  fun x => forall e, In _ (used (C ⟦ e ⟧)) x.
+
+Local Ltac clearpose H x e :=
+  pose (x := e); assert (H : x = e) by (subst x; reflexivity); clearbody x.
+
+Local Ltac insts_disagree H spec1 spec2 :=
+  pose (Hx1 := H spec1); clearbody Hx1; simpl in Hx1;
+  pose (Hx2 := H spec2); clearbody Hx2; simpl in Hx2;
+  repeat normalize_used_vars; inversion Hx1; now inversion Hx2.
+
+Lemma used_c_nil {A} : used_c (<[]> : exp_c A A) <--> Empty_set _.
+Proof.
+  split; [|auto with Ensembles_DB].
+  intros x Hx; unfold In, used_c in Hx; simpl in Hx.
+  destruct A; simpl in Hx.
+  - insts_disagree Hx (mk_ctor_tag xH, Ehalt (mk_var xH)) (mk_ctor_tag xH, Ehalt (mk_var (xO xH))).
+  - specialize (Hx []); assumption.
+  - specialize (Hx Fnil); simpl in Hx; now normalize_used_vars.
+  - insts_disagree Hx (Ehalt (mk_var xH)) (Ehalt (mk_var (xO xH))).
+  - insts_disagree Hx (mk_var xH) (mk_var (xO xH)).
+  - apply Hx; exact (mk_fun_tag xH).
+  - apply Hx; exact (mk_ctor_tag xH).
+  - apply Hx; exact (mk_prim xH).
+  - apply Hx; exact N0.
+  - specialize (Hx []); inversion Hx.
+Qed. *)
+
+Definition used_frame {A B} (f : exp_frame_t A B) : Ensemble cps.var. refine (
+  match f with
+  | pair_ctor_tag_exp0 e => used_vars e
+  | pair_ctor_tag_exp1 c => Empty_set _
+  | cons_prod_ctor_tag_exp0 ces => used_ces ces
+  | cons_prod_ctor_tag_exp1 (_, e) => used_vars e
+  | Fcons0 ft xs e fds => FromList xs :|: used_vars e :|: used_vars_fundefs fds
+  | Fcons1 f xs e fds => f |: FromList xs :|: used_vars e :|: used_vars_fundefs fds
+  | Fcons2 f ft e fds => f |: used_vars e :|: used_vars_fundefs fds
+  | Fcons3 f ft xs fds => f |: FromList xs :|: used_vars_fundefs fds
+  | Fcons4 f ft xs e => f |: FromList xs :|: used_vars e
+  | Econstr0 c ys e => FromList ys :|: used_vars e
+  | Econstr1 x ys e => x |: FromList ys :|: used_vars e
+  | Econstr2 x c e => x |: used_vars e
+  | Econstr3 x c ys => x |: FromList ys
+  | Ecase0 ces => used_ces ces
+  | Ecase1 x => [set x]
+  | Eproj0 c n y e => y |: used_vars e
+  | Eproj1 x n y e => x |: (y |: used_vars e)
+  | Eproj2 x c y e => x |: (y |: used_vars e)
+  | Eproj3 x c n e => x |: used_vars e
+  | Eproj4 x c n y => x |: [set y]
+  | Eletapp0 f ft ys e => f |: FromList ys :|: used_vars e
+  | Eletapp1 x ft ys e => x |: FromList ys :|: used_vars e
+  | Eletapp2 x f ys e => x |: (f |: FromList ys :|: used_vars e)
+  | Eletapp3 x f ft e => x |: (f |: used_vars e)
+  | Eletapp4 x f ft ys => x |: (f |: FromList ys)
+  | Efun0 e => used_vars e
+  | Efun1 fds => used_vars_fundefs fds
+  | Eapp0 ft xs => FromList xs
+  | Eapp1 f xs => f |: FromList xs
+  | Eapp2 f ft => [set f]
+  | Eprim0 p ys e => FromList ys :|: used_vars e
+  | Eprim1 x ys e => x |: FromList ys :|: used_vars e
+  | Eprim2 x p e => x |: used_vars e
+  | Eprim3 x p ys => x |: FromList ys
+  | Ehalt0 => Empty_set _
+  end).
+Defined.
+
+Lemma used_frameD {A B} (f : exp_frame_t A B) (x : univD A) :
+  used (frameD f x) <--> used_frame f :|: used x.
+Proof.
+  destruct f; simpl in *|-;
+  repeat match goal with p : _ * _ |- _ => destruct p end; simpl;
+  repeat normalize_used_vars;
+  repeat normalize_sets;
+  try solve [rewrite Ensemble_iff_In_iff; intros arbitrary; repeat rewrite In_or_Iff_Union; tauto].
+  - induction l as [| [c e] ces IHces]; simpl; repeat normalize_used_vars; [eauto with Ensembles_DB|].
+    rewrite IHces; eauto with Ensembles_DB.
+  - induction x as [| [c e] ces IHces]; simpl; repeat normalize_used_vars; [eauto with Ensembles_DB|].
+    rewrite IHces; eauto with Ensembles_DB.
+Qed.
+
+Fixpoint used_c {A B} (C : exp_c A B) : Ensemble cps.var :=
+  match C with
+  | <[]> => Empty_set _
+  | C >:: f => used_c C :|: used_frame f
+  end.
+
+Lemma used_c_comp {A B root} (C : exp_c B root) (D : exp_c A B) :
+  used_c (C >++ D) <--> used_c C :|: used_c D.
+Proof. induction D; simpl; [|rewrite IHD]; eauto with Ensembles_DB. Qed.
+
+Lemma used_app {A B} (C : exp_c A B) (e : univD A) :
+  used (C ⟦ e ⟧) <--> used_c C :|: used e.
+Proof.
+  induction C; simpl; [eauto with Ensembles_DB|].
+  rewrite IHC, used_frameD; eauto with Ensembles_DB.
+Qed.
+
+Corollary used_vars_app (C : exp_c exp_univ_exp exp_univ_exp) (e : exp) :
+  used_vars (C ⟦ e ⟧) <--> used_c C :|: used_vars e.
+Proof. change (used_vars ?e) with (@used exp_univ_exp e); apply @used_app. Qed.
+
+Corollary used_vars_fundefs_app (C : exp_c exp_univ_fundefs exp_univ_exp) (fds : fundefs) :
+  used_vars (C ⟦ fds ⟧) <--> used_c C :|: used_vars_fundefs fds.
+Proof. change (used_vars ?e) with (@used exp_univ_exp e); apply @used_app. Qed.
+
+(* Useful fact for some of the passes: every C : exp_c exp_univ_fundefs exp_univ_exp
+   can be decomposed into D, fds, e such that C = D ∘ (Efun (rev fds ++ _) e) *)
+
+Fixpoint ctx_of_fds (fds : fundefs) : exp_c exp_univ_fundefs exp_univ_fundefs :=
+  match fds with
+  | Fnil => <[]>
+  | Fcons f ft xs e fds => ctx_of_fds fds >:: Fcons4 f ft xs e
+  end.
+
+Fixpoint fundefs_rev (fds : fundefs) : fundefs :=
+  match fds with
+  | Fnil => Fnil
+  | Fcons f ft xs e fds => fundefs_append (fundefs_rev fds) (Fcons f ft xs e Fnil)
+  end.
+
+Lemma ctx_of_fds_app (fds1 : fundefs) : forall fds2 : fundefs,
+  ctx_of_fds fds1 ⟦ fds2 ⟧ = fundefs_append (fundefs_rev fds1) fds2.
+Proof.
+  induction fds1 as [f ft xs e fds1 IHfds1|]; [|reflexivity].
+  intros fds2; cbn. rewrite IHfds1, <- fundefs_append_assoc. reflexivity.
+Qed.
+
+Fixpoint decompose_fd_c' {A B} (C : exp_c A B) {struct C} :
+  match A as A', B as B' return exp_c A' B' -> Set with
+  | exp_univ_fundefs, exp_univ_exp => fun C => {'(D, fds, e) | C = D >:: Efun0 e >++ ctx_of_fds fds}
+  | _, _ => fun _ => unit
+  end C.
+Proof.
+  destruct C as [|A AB B f C]; [destruct A; exact tt|destruct f, B; try exact tt].
+  - specialize (decompose_fd_c' exp_univ_fundefs exp_univ_exp C); simpl in decompose_fd_c'.
+    destruct decompose_fd_c' as [[[C' fds'] e'] HCfdse'].
+    exists (C', Fcons v f l e fds', e'); now simpl.
+  - exists (C, Fnil, e); now simpl.
+Defined.
+
+Definition decompose_fd_c := @decompose_fd_c' exp_univ_fundefs exp_univ_exp.
+
+(* Misc. facts that may or may not be useful when dealing with dependently typed [exp_c]s *)
+
+Instance exp_Frame_inj : Frame_inj (U:=exp_univ).
+Proof. intros A B f x y; destruct f; now inversion 1. Qed.
+
+Require Import Coq.Logic.JMeq.
+Require Import Coq.Logic.Eqdep.
+Ltac inv_ex :=
+  repeat progress match goal with
+  | H : existT ?P ?T _ = existT ?P ?T _ |- _ => apply inj_pairT2 in H
+  end.
+
+(* Inhabited types *)
+
+Class Inhabited A := inhabitant : A.
+
+Instance Inhabited_pos : Inhabited positive := xH.
+Instance Inhabited_N : Inhabited N := N0.
+
+Instance Inhabited_list A : Inhabited (list A) := [].
+Instance Inhabited_prod A B `{Inhabited A} `{Inhabited B} : Inhabited (A * B) := (inhabitant, inhabitant).
+
+Instance Inhabited_exp : Inhabited exp := Ehalt inhabitant.
+Instance Inhabited_fundefs : Inhabited fundefs := Fnil.
+
+Definition univ_inhabitant {A} : univD A :=
+  match A with
+  | exp_univ_prod_ctor_tag_exp => inhabitant
+  | exp_univ_list_prod_ctor_tag_exp => inhabitant
+  | exp_univ_fundefs => inhabitant
+  | exp_univ_exp => inhabitant
+  | exp_univ_var => inhabitant
+  | exp_univ_fun_tag => inhabitant
+  | exp_univ_ctor_tag => inhabitant
+  | exp_univ_prim => inhabitant
+  | exp_univ_N => inhabitant
+  | exp_univ_list_var => inhabitant
+  end.
+
+Class Sized A := size : A -> nat.
+
+Instance Sized_pos : Sized positive := fun _ => S O.
+Instance Sized_N : Sized N := fun _ => S O.
+
+Definition size_list {A} (size : A -> nat) : list A -> nat := fold_right (fun x n => S (size x + n)) 1%nat.
+Definition size_prod {A B} (sizeA : A -> nat) (sizeB : B -> nat) : A * B -> nat := fun '(x, y) => S (sizeA x + sizeB y).
+
+Instance Size_list A `{Sized A} : Sized (list A) := size_list size.
+Instance Size_prod A B `{Sized A} `{Sized B} : Sized (A * B) := size_prod size size.
+
+Fixpoint size_exp (e : exp) : nat
+with size_fundefs (fds : fundefs) : nat.
+Proof.
+- refine (match e with
+  | Econstr x c ys e => S (size x + size c + size ys + size_exp e)
+  | Ecase x ces => S (size x + size_list (size_prod size size_exp) ces)
+  | Eproj x c n y e => S (size x + size c + size n + size y + size_exp e)
+  | Eletapp x f ft ys e => S (size x + size f + size ft + size ys + size_exp e)
+  | Efun fds e => S (size_fundefs fds + size_exp e)
+  | Eapp f ft xs => S (size f + size ft + size xs)
+  | Eprim x p ys e => S (size x + size p + size ys + size_exp e)
+  | Ehalt x => S (size x)
+  end).
+- refine (match fds with
+  | Fnil => 1%nat
+  | Fcons f ft xs e fds => S (size f + size ft + size xs + size_exp e + size_fundefs fds)
+  end).
+Defined.
+
+Instance Sized_exp : Sized exp := size_exp.
+Instance Sized_fundefs : Sized fundefs := size_fundefs.
+
+Definition univ_size {A} : univD A -> nat :=
+  match A with
+  | exp_univ_prod_ctor_tag_exp => size
+  | exp_univ_list_prod_ctor_tag_exp => size
+  | exp_univ_fundefs => size
+  | exp_univ_exp => size
+  | exp_univ_var => size
+  | exp_univ_fun_tag => size
+  | exp_univ_ctor_tag => size
+  | exp_univ_prim => size
+  | exp_univ_N => size
+  | exp_univ_list_var => size
+  end.
+
+Lemma size_app {A} `{Sized A} (xs ys : list A) : size (xs ++ ys) < size xs + size ys.
+Proof. induction xs as [|x xs IHxs]; cbn; lia. Qed.
+
+Lemma frame_size_gt {A B} (f : exp_frame_t A B) (x : univD A) :
+  (univ_size (frameD f x) > univ_size x)%nat.
+Proof.
+  destruct f; cbn;
+  try change (size_exp x) with (size x); cbn;
+  try change (size_fundefs x) with (size x); cbn;
+  try change (size_list (size_prod size size) x) with (size x); cbn;
+  try change (size x) with 1; cbn;
+  try lia.
+Qed.
+
+Lemma exp_c_size_ge {A B} (C : exp_c A B) (x : univD A) :
+  (univ_size (C ⟦ x ⟧) >= univ_size x)%nat.
+Proof.
+  induction C as [|A AB B f C]; simpl; [lia|].
+  assert (univ_size (C ⟦ exp_frameD A AB f x ⟧) >= univ_size (frameD f x))%nat by apply IHC.
+  assert (univ_size (frameD f x) > univ_size x)%nat by apply frame_size_gt.
+  lia.
+Qed.
+
+Definition exp_c_size_eq {A B} (C : exp_c A B) (x : univD A) :
+  univ_size (C ⟦ x ⟧) = univ_size x -> JMeq C (<[]> : exp_c A A).
+Proof.
+  destruct C as [|A AB B f C]; simpl; [constructor|intros HC].
+  assert (univ_size (C ⟦ exp_frameD A AB f x ⟧) >= univ_size (exp_frameD A AB f x))%nat
+   by apply exp_c_size_ge.
+  assert (univ_size (exp_frameD A AB f x) > univ_size x)%nat by apply frame_size_gt.
+  lia.
+Qed.
+
+Lemma exp_ext_nil {A B} (C : exp_c A B) : A = B -> (forall x, JMeq x (C ⟦ x ⟧)) -> JMeq C (<[]> : exp_c A A).
+Proof.
+  destruct C as [|A AB B f C]; [constructor|simpl].
+  intros HeqB Hext; subst; specialize (Hext univ_inhabitant).
+  inversion Hext; inv_ex.
+  apply f_equal with (f := univ_size) in H.
+  match type of Hext with
+  | JMeq _ (?C ⟦ ?f ⟧) =>
+    match f with
+    | exp_frameD _ _ _ ?x =>
+      assert (univ_size (C ⟦ f ⟧) >= univ_size f)%nat by apply exp_c_size_ge;
+      assert (univ_size f > univ_size x)%nat by apply frame_size_gt;
+      lia
+    end
+  end.
+Qed.
+
+Corollary exp_ext_nil' {A B} (C : exp_c A B) : A = B -> (forall x, JMeq x (C ⟦ x ⟧)) -> JMeq C (<[]> : exp_c B B).
+Proof. intros; subst; now apply exp_ext_nil. Qed.

--- a/theories/L6_PCPS/proto_util.v
+++ b/theories/L6_PCPS/proto_util.v
@@ -1,0 +1,396 @@
+Require Import Coq.Strings.String Coq.Classes.Morphisms Coq.Relations.Relations.
+Require Import Coq.PArith.BinPos Coq.Sets.Ensembles Lia.
+Require Import L6.identifiers L6.Prototype L6.cps_proto L6.cps L6.cps_util.
+Require Import L6.Ensembles_util L6.rename L6.shrink_cps L6.map_util.
+
+Require Import Coq.Lists.List.
+Import ListNotations.
+
+Definition fresher_than (x : var) (S : Ensemble var) : Prop :=
+  forall y, y \in S -> (x > y)%positive.
+
+Lemma fresher_than_not_In x S : fresher_than x S -> ~ x \in S.
+Proof. intros Hfresh Hin; assert (x > x)%positive by now apply Hfresh. lia. Qed.
+
+Lemma fresher_than_antimon x S1 S2 : S1 \subset S2 -> fresher_than x S2 -> fresher_than x S1.
+Proof. intros HS12 Hfresh y Hy; apply Hfresh, HS12, Hy. Qed.
+
+Lemma fresher_than_monotonic x y S : (y >= x -> fresher_than x S -> fresher_than y S)%positive.
+Proof. intros Hxy Hfresh z Hz. assert (x > z)%positive by now apply Hfresh. lia. Qed.
+
+Lemma fresher_than_Union x S1 S2 : fresher_than x S1 -> fresher_than x S2 -> fresher_than x (S1 :|: S2).
+Proof. intros HS1 HS2 y Hy; destruct Hy as [y Hy|y Hy]; auto. Qed.
+
+Instance Proper_fresher_than_r : Proper (Logic.eq ==> Same_set _ ==> iff) fresher_than.
+Proof.
+  unfold Proper, "==>", fresher_than.
+  intros x y Hxy x0 y0 Hxy0; subst; split; intros Hforall dummy; now (rewrite <- Hxy0 || rewrite Hxy0).
+Qed.
+
+Definition fresh_copies (S : Ensemble var) (l : list var) : Prop := Disjoint _ S (FromList l) /\ NoDup l.
+
+Definition gensym (x : var) : var * var := (x + 1, x)%positive.
+
+Lemma gensym_spec x S x' y : 
+  fresher_than x S ->
+  (x', y) = gensym x ->
+  ~ y \in S /\ fresher_than x' (y |: S).
+Proof.
+  unfold gensym; intros Hfresh Hgen; split.
+  - intros Hy.
+    assert (y = x) by now simpl in *.
+    assert (x > y)%positive by now apply Hfresh.
+    lia.
+  - assert (x' = (x + 1)%positive) by easy; assert (y = x) by easy.
+    assert (x' > y)%positive by lia.
+    apply fresher_than_Union; [|eapply fresher_than_monotonic; try eassumption; lia].
+    simpl; intros z Hz; inversion Hz; lia.
+Qed.
+
+Fixpoint gensyms {A} (x : var) (xs : list A) : var * list var :=
+  match xs with
+  | [] => (x, [])
+  | _ :: xs => let '(x', xs') := gensyms (x + 1)%positive xs in (x', x :: xs')
+  end.
+
+Lemma gensyms_len' {A} : forall x (xs : list A) x' xs', (x', xs') = gensyms x xs -> length xs' = length xs.
+Proof.
+  intros x xs; revert x; induction xs as [|x xs IHxs]; intros x0 x' xs' Hgen; [simpl in Hgen; now inv Hgen|].
+  unfold gensyms in Hgen; fold @gensyms in Hgen.
+  destruct (gensyms (x0 + 1)%positive xs) as [x'' xs''] eqn:Hx0; inv Hgen; now simpl.
+Qed.
+
+Lemma gensyms_increasing' {A} :
+  forall x (xs : list A) x' xs', (x', xs') = gensyms x xs -> 
+  forall y, List.In y xs' -> (y >= x)%positive.
+Proof.
+  intros x xs; revert x; induction xs as [|x xs IHxs]; intros x0 x' xs' Hgen y Hy;
+    [simpl in Hgen; now inv Hgen|].
+  unfold gensyms in Hgen; fold @gensyms in Hgen.
+  destruct (gensyms (x0 + 1)%positive xs) as [x'' xs''] eqn:Hx0; inv Hgen; simpl.
+  simpl in Hy; destruct Hy as [H|H]; [inversion H; simpl; lia|].
+  specialize IHxs with (x := (x0 + 1)%positive) (y := y).
+  rewrite Hx0 in IHxs; unfold snd in IHxs.
+  specialize (IHxs x'' xs'' eq_refl H); lia.
+Qed.
+
+Local Ltac mk_corollary parent := 
+  intros x xs x' xs';
+  pose (Hparent := parent _ x xs); clearbody Hparent; intros H;
+  destruct (gensyms x xs); now inversion H.
+
+Lemma gensyms_upper {A} x (xs : list A) :
+  (fst (gensyms x xs) >= x)%positive /\
+  forall y, List.In y (snd (gensyms x xs)) -> (fst (gensyms x xs) > y)%positive.
+Proof.
+  revert x; induction xs; [simpl; split; [lia|easy]|intros x; split; [|intros y Hy]].
+  - unfold gensyms; fold @gensyms.
+    destruct (gensyms _ _) as [x' xs'] eqn:Hxs'; unfold fst.
+    specialize (IHxs (x + 1)%positive); rewrite Hxs' in IHxs; unfold fst in IHxs.
+    destruct IHxs; lia.
+  - unfold gensyms in *; fold @gensyms in *.
+    destruct (gensyms _ _) as [x' xs'] eqn:Hxs'; unfold fst; unfold snd in Hy.
+    specialize (IHxs (x + 1)%positive); rewrite Hxs' in IHxs; unfold fst in IHxs.
+    destruct IHxs as [IHxs IHxsy].
+    destruct Hy as [Hy|Hy]; [inversion Hy; simpl; lia|].
+    now specialize (IHxsy y Hy).
+Qed.
+
+Corollary gensyms_upper1 {A} : forall x (xs : list A) x' xs', (x', xs') = gensyms x xs -> (x' >= x)%positive.
+Proof. mk_corollary @gensyms_upper. Qed.
+
+Corollary gensyms_upper2 {A} :
+  forall x (xs : list A) x' xs', (x', xs') = gensyms x xs ->
+  forall y, List.In y xs' -> (x' > y)%positive.
+Proof. mk_corollary @gensyms_upper. Qed.
+
+Lemma gensyms_NoDup {A} x (xs : list A) : NoDup (snd (gensyms x xs)).
+Proof.
+  revert x; induction xs; intros; [now constructor|].
+  unfold gensyms; fold @gensyms.
+  destruct (gensyms _ _) as [x' xs'] eqn:Hxs'; unfold snd.
+  specialize (IHxs (x + 1)%positive); rewrite Hxs' in IHxs; unfold snd in IHxs.
+  constructor; [|auto].
+  pose (Hinc := gensyms_increasing' (x + 1)%positive xs); clearbody Hinc.
+  rewrite Hxs' in Hinc; unfold snd in Hinc.
+  remember (snd (gensyms (x + 1)%positive xs)) as ys; clear - Hinc.
+  induction xs'; auto.
+  specialize (Hinc x' (a :: xs')).
+  intros [|Hin_ys]; [|apply IHxs'; auto; intros; apply Hinc; auto; now right].
+  assert (Hxa : In x (a :: xs')) by now left.
+  specialize (Hinc eq_refl x Hxa); lia.
+Qed.
+
+Corollary gensyms_NoDup' {A} : forall x (xs : list A) x' xs', (x', xs') = gensyms x xs -> NoDup xs'.
+Proof. mk_corollary @gensyms_NoDup. Qed.
+
+Lemma gensyms_fresher_than {A} (xs : list A) :
+  forall x y S x' xs',
+  fresher_than x S ->
+  (y >= x)%positive ->
+  (x', xs') = gensyms y xs ->
+  Disjoint _ S (FromList xs').
+Proof.
+  induction xs.
+  - simpl; intros x y S x' xs' Hfresh Hyx Hgen; inversion Hgen; subst.
+    simpl; normalize_sets; eauto with Ensembles_DB.
+  - unfold gensyms; fold @gensyms; intros x y S x' xs' Hfresh Hyx Hgen.
+    destruct (gensyms (y + 1)%positive xs) as [x'' xs''] eqn:Hxs.
+    inversion Hgen; subst; simpl; normalize_sets.
+    apply Union_Disjoint_r; [|eapply (IHxs (y + 1)%positive); eauto; try lia].
+    + unfold fresher_than in Hfresh.
+      constructor; intros arb; intros HSx; unfold Ensembles.In in HSx.
+      destruct HSx as [arb HS Hx]; inversion Hx; subst.
+      specialize (Hfresh _ HS); lia.
+    + eapply fresher_than_monotonic; eauto; lia.
+Qed.
+
+Ltac show_Disjoint arb Harbx Harby :=
+  let Harb := fresh "Harb" in
+  constructor; intros arb Harb; unfold Ensembles.In in Harb;
+  destruct Harb as [arb Harbx Harby].
+
+Lemma gensyms_disjoint {A B} (xs : list A) (ys : list B) x0 x1 x2 xs' ys' :
+  (x1, xs') = gensyms x0 xs ->
+  (x2, ys') = gensyms x1 ys ->
+  Disjoint _ (FromList xs') (FromList ys').
+Proof.
+  intros Hxs' Hys'; show_Disjoint arb Harbx Harby.
+  unfold Ensembles.In, FromList in Harbx, Harby.
+  assert (x1 > arb)%positive by (eapply gensyms_upper2; eassumption); simpl in *.
+  assert (arb >= x1)%positive by (eapply gensyms_increasing'; eassumption); simpl in *.
+  lia.
+Qed.
+
+Lemma gensyms_list_fresher {A} x y (ys : list A) y' ys' S :
+  fresher_than x S ->
+  (y >= x)%positive ->
+  (y', ys') = gensyms y ys ->
+  Disjoint _ S (FromList ys').
+Proof.
+  intros Hfresh Hyx Hgen; show_Disjoint arb Harbx Harby.
+  unfold Ensembles.In, FromList in Harby.
+  assert (arb >= y)%positive by (eapply gensyms_increasing'; eauto); simpl in *.
+  assert (x > arb)%positive by now apply Hfresh.
+  lia.
+Qed.
+
+Lemma gensyms_spec {A} x S (xs : list A) x' xs' : 
+  fresher_than x S ->
+  (x', xs') = gensyms x xs ->
+  fresh_copies S xs' /\ fresher_than x' (S :|: FromList xs') /\ length xs' = length xs.
+Proof.
+  intros Hfresh Hgen; unfold fresh_copies; split; [split|split].
+  - show_Disjoint arb Harbx Harby.
+    unfold Ensembles.In, FromList in Harby.
+    assert (x > arb)%positive by now apply Hfresh.
+    assert (arb >= x)%positive by (eapply gensyms_increasing'; eauto).
+    simpl in *; lia.
+  - eapply gensyms_NoDup'; eauto.
+  - intros y Hy; destruct Hy as [y Hy|y Hy].
+    + assert (x > y)%positive by now apply Hfresh.
+      assert (x' >= x)%positive by (eapply gensyms_upper1; eauto); lia.
+    + unfold Ensembles.In, FromList in Hy.
+      simpl in Hy; normalize_roundtrips.
+      eapply gensyms_upper2; eauto.
+  - eapply gensyms_len'; eauto.
+Qed.
+
+Section RunRewriter.
+
+Context 
+  {Root : exp_univ} {fueled : bool} {metric : Metric Root fueled} {Rstep : relation (univD Root)}
+  {D : Set} {I_D : forall A, univD A -> D -> Prop} `{@Delayed _ Frame_exp D I_D}
+  {R : Set} {I_R : forall A, frames_t A Root -> R -> Prop}
+  {S : Set} {I_S : forall A, frames_t A Root -> univD A -> S -> Prop}
+  `{@Preserves_R _ Frame_exp _ R I_R}
+  `{@Preserves_S_dn _ Frame_exp _ S I_S}
+  `{@Preserves_S_up _ Frame_exp _ S I_S}
+  (rw : rewriter Root fueled metric Rstep D I_D R I_R S I_S).
+
+Definition run_rewriter' :
+  forall (e : univD Root), Param I_R (erase <[]>) -> State I_S (erase <[]>) e ->
+  result Rstep I_S (erase <[]>) e.
+Proof.
+  intros e r s; unfold rewriter, rewriter', rw_for in rw.
+  destruct fueled.
+  - specialize (rw lots_of_fuel _ (erase <[]>) _ e (delay_id _)).
+    rewrite delay_id_law in rw.
+    specialize (rw (erase (Pos.to_nat lots_of_fuel)) _ r s); apply rw; unerase.
+    unfold run_metric; destruct metric; reflexivity.
+  - specialize (rw I _ (erase <[]>) _ e (delay_id _)).
+    rewrite delay_id_law in rw; unshelve eapply rw;
+    try lazymatch goal with
+    | |- erased nat => refine (erase _)
+    | |- Param _ _ => assumption
+    | |- State _ _ _ => assumption
+    end;
+    try lazymatch goal with
+    | |- e_ok (erase _) => apply erase_ok
+    | |- «_» => unerase; reflexivity
+    end.
+Defined.
+
+Definition run_rewriter (e : univD Root)
+           (r : Param I_R (erase <[]>)) (s : State I_S (erase <[]>) e) : univD Root :=
+  let '{| resTree := e' |} := run_rewriter' e r s in e'.
+
+End RunRewriter.
+
+Definition I_S_fresh {A} (C : exp_c A exp_univ_exp) (e : univD A) (x : var) : Prop :=
+  fresher_than x (used_vars (C ⟦ e ⟧)).
+
+(* We don't have to do anything to preserve a fresh variable as we move around *)
+Instance Preserves_S_dn_S_fresh : Preserves_S_dn (@I_S_fresh).
+Proof. unfold Preserves_S_dn; intros A B C C_ok f x s; exact s. Defined.
+Instance Preserves_S_up_S_fresh : Preserves_S_up (@I_S_fresh).
+Proof. unfold Preserves_S_up; intros A B C C_ok f x s; exact s. Defined.
+Extraction Inline Preserves_S_dn_S_fresh Preserves_S_up_S_fresh.
+
+(* Compute an initial fresh variable *)
+Definition initial_fresh (e : exp) : State (@I_S_fresh) (erase <[]>) e.
+Proof.
+  exists (1 + max_var e 1)%positive; unerase; unfold I_S_fresh.
+  change (![ <[]> ⟦ ?e ⟧ ]) with e; unfold fresher_than.
+  intros y Hy; enough (y <= max_var e 1)%positive by lia.
+  destruct Hy; [now apply bound_var_leq_max_var|now apply occurs_free_leq_max_var].
+Defined.
+
+(* Some passes assume unique bindings *)
+Definition I_S_uniq {A} (C : exp_c A exp_univ_exp) (e : univD A) (_ : unit) : Prop :=
+  unique_bindings (C ⟦ e ⟧).
+Instance Preserves_S_dn_S_uniq : Preserves_S_dn (@I_S_uniq).
+Proof. unfold Preserves_S_dn; intros A B C C_ok f x s; exact s. Defined.
+Instance Preserves_S_up_S_uniq : Preserves_S_up (@I_S_uniq).
+Proof. unfold Preserves_S_up; intros A B C C_ok f x s; exact s. Defined.
+Extraction Inline Preserves_S_dn_S_uniq Preserves_S_up_S_uniq.
+
+(* Additional facts about variables *)
+
+Fixpoint bound_var_ces (ces : list (cps.ctor_tag * cps.exp)) :=
+  match ces with
+  | [] => Empty_set _
+  | (c, e) :: ces => bound_var e :|: bound_var_ces ces
+  end.
+
+Lemma bound_var_Ecase x ces : bound_var (cps.Ecase x ces) <--> bound_var_ces ces.
+Proof.
+  induction ces as [|[c e] ces IHces].
+  - rewrite bound_var_Ecase_nil; now cbn.
+  - rewrite bound_var_Ecase_cons; cbn; rewrite IHces; eauto with Ensembles_DB.
+Qed.
+
+Fixpoint used_vars_ces (ces : list (cps.ctor_tag * cps.exp)) :=
+  match ces with
+  | [] => Empty_set _
+  | (c, e) :: ces => used_vars e :|: used_vars_ces ces
+  end.
+
+Lemma used_vars_Ecase x ces : used_vars (cps.Ecase x ces) <--> x |: used_vars_ces ces.
+Proof.
+  induction ces as [|[c e] ces IHces].
+  - rewrite used_vars_Ecase_nil; cbn; now normalize_sets.
+  - rewrite used_vars_Ecase_cons; cbn; rewrite IHces; eauto with Ensembles_DB.
+Qed.
+
+(* Renaming *)
+
+(* TODO: combine with shrink_cps renaming *)
+
+Definition r_map : Set := M.tree var.
+
+Require Import L6.shrink_cps_correct.
+
+Definition image'' σ : Ensemble var := fun y => exists x, M.get x σ = Some y.
+
+Lemma apply_r_vars σ x : [set apply_r σ x] \subset x |: image'' σ.
+Proof.
+  unfold apply_r.
+  destruct (cps.M.get x σ) as [y|] eqn:Hget; [|eauto with Ensembles_DB].
+  intros arb Harb; inv Harb; right; unfold image'', Ensembles.In; now exists x.
+Qed.
+  
+Lemma apply_r_list_vars σ xs :
+  FromList (apply_r_list σ xs) \subset FromList xs :|: image'' σ.
+Proof.
+  induction xs as [|x xs IHxs]; [eauto with Ensembles_DB|cbn in *].
+  repeat normalize_sets.
+  apply Union_Included.
+  - eapply Included_trans; [apply apply_r_vars|]; eauto with Ensembles_DB.
+  - eapply Included_trans; [apply IHxs|]; eauto with Ensembles_DB.
+Qed.
+
+Fixpoint rename_all_used σ e {struct e} :
+  used_vars (rename_all_ns σ e) \subset used_vars e :|: image'' σ.
+Proof.
+  destruct e; cbn in *; repeat normalize_used_vars.
+  Ltac solve_easy_rename_used IH :=
+    lazymatch goal with
+    | |- _ :|: _ \subset _ => apply Union_Included; solve_easy_rename_used IH
+    | |- [set apply_r _ _] \subset _ =>
+      clear IH; eapply Included_trans; [apply apply_r_vars|]; eauto with Ensembles_DB
+    | |- FromList (apply_r_list _ _) \subset _ =>
+      clear IH; eapply Included_trans; [apply apply_r_list_vars|]; eauto with Ensembles_DB
+    | |- used_vars _ \subset _ => eapply Included_trans; [apply IH|]; eauto with Ensembles_DB
+    | |- _ => solve [eauto with Ensembles_DB]
+    end.
+  all: try solve [solve_easy_rename_used rename_all_used]. Guarded.
+  - rewrite used_vars_Ecase; apply Union_Included; [solve_easy_rename_used rename_all_used|].
+    induction l as [|[c e] ces IHces]; cbn; [eauto with Ensembles_DB|].
+    repeat normalize_used_vars.
+    apply Union_Included; [solve_easy_rename_used rename_all_used|].
+    eapply Included_trans; [apply IHces|]; eauto with Ensembles_DB.
+  - apply Union_Included; [|solve_easy_rename_used rename_all_used].
+    induction f as [f ft xs e_body fds IHfds|]; cbn; [|eauto with Ensembles_DB].
+    repeat normalize_used_vars.
+    apply Union_Included; [solve_easy_rename_used rename_all_used|].
+    eapply Included_trans; [apply IHfds|]; eauto with Ensembles_DB.
+Qed.
+
+Lemma empty_image : image'' (M.empty _) <--> Empty_set _.
+Proof.
+  unfold image'', Ensembles.In; split; intros x Hx; inv Hx.
+  now rewrite M.gempty in H.
+Qed.
+
+Lemma set_lists_image'' xs ys σ σ' :
+  set_lists xs ys σ = Some σ' ->
+  image'' σ' \subset image'' σ :|: FromList ys.
+Proof.
+  revert ys σ σ'; induction xs as [|x xs IHxs]; destruct ys as [|y ys]; try solve [inversion 1].
+  - inversion 1; eauto with Ensembles_DB.
+  - intros σ σ' Hset; cbn in Hset.
+    destruct (set_lists xs ys σ) as [σ''|] eqn:Hσ''; inv Hset.
+    specialize (IHxs ys σ σ'' Hσ'').
+    intros arb [x' Hx']; specialize (IHxs arb); unfold Ensembles.In, image'' in *.
+    unfold apply_r in Hx'; change cps.M.get with M.get in *; change map_util.M.set with M.set in *.
+    destruct (Pos.eq_dec x' x) as [Heq|Hne]; [subst x'; rewrite M.gss in Hx'|rewrite M.gso in Hx' by auto].
+    + right; subst; now left.
+    + destruct IHxs as [Hσ|Hin_ys]; [eexists; eassumption|left|right; right]; auto.
+Qed.
+
+Lemma fresher_than_Empty_set x : fresher_than x (Empty_set _).
+Proof. intros y []. Qed.
+
+(* Some passes maintain map of known functions *)
+
+Definition fun_map : Set := M.tree (fun_tag * list var * exp).
+
+Fixpoint add_fundefs (fds : fundefs) (ρ : fun_map) : fun_map :=
+  match fds with
+  | Fcons f ft xs e fds => M.set f (ft, xs, e) (add_fundefs fds ρ)
+  | Fnil => ρ
+  end.
+
+Fixpoint add_fundefs_Some f ft xs e ρ fds {struct fds} :
+  M.get f (add_fundefs fds ρ) = Some (ft, xs, e) ->
+  (exists fds1 fds2, fds = fundefs_append fds1 (Fcons f ft xs e fds2)) \/
+  M.get f ρ = Some (ft, xs, e).
+Proof.
+  destruct fds as [g gt ys e' fds|]; [cbn; intros Hget|now right].
+  destruct (Pos.eq_dec f g); [subst; rewrite M.gss in Hget; inv Hget; left; now exists Fnil, fds|].
+  rewrite M.gso in Hget by auto.
+  specialize (add_fundefs_Some _ _ _ _ ρ fds Hget).
+  destruct add_fundefs_Some as [[fds1 [fds2 Heq]]|Hin]; [|now right].
+  left; subst fds. exists (Fcons g gt ys e' fds1), fds2. reflexivity.
+Qed.

--- a/theories/L6_PCPS/scoping.v
+++ b/theories/L6_PCPS/scoping.v
@@ -1,0 +1,565 @@
+Require Import Coq.Strings.String.
+Require Import Coq.Sets.Ensembles Coq.ZArith.ZArith.
+Require Import L6.Ensembles_util L6.map_util L6.List_util.
+Require Import L6.state L6.alpha_conv L6.identifiers L6.functions L6.shrink_cps L6.stemctx.
+Require Import L6.Prototype.
+Require Import L6.cps_proto L6.proto_util.
+
+Require Import Lia.
+
+Require Import Coq.Lists.List.
+Import ListNotations.
+
+(* TODO: move to proto_util *)
+
+Fixpoint occurs_free_ces (ces : list (cps.ctor_tag * cps.exp)) :=
+  match ces with
+  | [] => Empty_set _
+  | (c, e) :: ces => occurs_free e :|: occurs_free_ces ces
+  end.
+
+Lemma occurs_free_Ecase x ces :
+  occurs_free (cps.Ecase x ces) <--> x |: occurs_free_ces ces.
+Proof.
+  induction ces as [|[c e] ces IHces]; cbn; repeat normalize_occurs_free; [eauto with Ensembles_DB|].
+  rewrite IHces; split; eauto 3 with Ensembles_DB.
+Qed.
+
+Lemma used_vars_ces_bv_fv ces :
+  used_vars_ces ces <--> bound_var_ces ces :|: occurs_free_ces ces.
+Proof.
+  induction ces as [|[c e] ces IHces]; cbn; eauto with Ensembles_DB.
+  rewrite IHces; unfold used_vars; split; eauto with Ensembles_DB.
+Qed.
+
+Lemma occurs_free_ctx_mut :
+  (forall (c : ctx.exp_ctx) (e e' : cps.exp),
+   occurs_free e \subset occurs_free e' ->
+   occurs_free (ctx.app_ctx_f c e) \subset occurs_free (ctx.app_ctx_f c e')) /\
+  (forall (B : ctx.fundefs_ctx) (e e' : cps.exp),
+   occurs_free e \subset occurs_free e' ->
+   occurs_free_fundefs (ctx.app_f_ctx_f B e) \subset occurs_free_fundefs (ctx.app_f_ctx_f B e')).
+Proof.
+  apply ctx.exp_fundefs_ctx_mutual_ind; intros; cbn; repeat normalize_occurs_free;
+  rewrite <- ?name_in_fundefs_ctx_ctx; eauto with Ensembles_DB.
+Qed.
+Corollary occurs_free_exp_ctx c e e' :
+  occurs_free e \subset occurs_free e' ->
+  occurs_free (ctx.app_ctx_f c e) \subset occurs_free (ctx.app_ctx_f c e').
+Proof. apply occurs_free_ctx_mut. Qed.
+Corollary occurs_free_fundefs_ctx B e e' :
+  occurs_free e \subset occurs_free e' ->
+  occurs_free_fundefs (ctx.app_f_ctx_f B e) \subset occurs_free_fundefs (ctx.app_f_ctx_f B e').
+Proof. apply occurs_free_ctx_mut. Qed.
+
+Definition well_scoped e := unique_bindings e /\ Disjoint _ (bound_var e) (occurs_free e).
+Definition well_scoped_fds fds :=
+  unique_bindings_fundefs fds /\ Disjoint _ (bound_var_fundefs fds) (occurs_free_fundefs fds).
+
+(* TODO: Move to Ensembles_util.v *)
+Lemma Disjoint_Setminus_bal : forall {A} (S1 S2 S3 : Ensemble A),
+  Disjoint _ (S1 \\ S3) (S2 \\ S3) ->
+  Disjoint _ (S1 \\ S3) S2.
+Proof.
+  clear; intros A S1 S2 S3 [Hdis]; constructor; intros arb.
+  intros [arb' [HS1 HS3] HS2]; clear arb.
+  apply (Hdis arb'); constructor; constructor; auto.
+Qed.
+
+Ltac DisInc H := eapply Disjoint_Included_l; [|eapply Disjoint_Included_r; [|apply H]].
+Lemma stem_not_free_mut :
+  (forall (c : ctx.exp_ctx) (e_arb e : cps.exp),
+    well_scoped (ctx.app_ctx_f c e_arb) ->
+    Disjoint _ (bound_stem_ctx c) (occurs_free (ctx.app_ctx_f c e))) /\
+  (forall (B : ctx.fundefs_ctx) (e_arb e : cps.exp),
+    well_scoped_fds (ctx.app_f_ctx_f B e_arb) ->
+    Disjoint _ (names_in_fundefs_ctx B :|: bound_stem_fundefs_ctx B)
+             (occurs_free_fundefs (ctx.app_f_ctx_f B e))).
+Proof. 
+  apply ctx.exp_fundefs_ctx_mutual_ind; unfold well_scoped.
+  - intros e_arb e [Huniq Hdis]; cbn in *.
+    normalize_bound_stem_ctx; eauto with Ensembles_DB.
+  - intros x c ys C IH e_arb e [Huniq Hdis]; cbn in *.
+    normalize_bound_stem_ctx; normalize_occurs_free; eauto with Ensembles_DB.
+    inv Huniq; change (~ ?S ?x) with (~ x \in S) in *.
+    revert Hdis; repeat (normalize_bound_var || normalize_occurs_free); intros Hdis.
+    apply Union_Disjoint_l; apply Union_Disjoint_r.
+    + rewrite bound_var_app_ctx, Union_demorgan in H1.
+      rewrite bound_var_app_ctx in Hdis.
+      DisInc Hdis; eauto with Ensembles_DB.
+      do 2 apply Included_Union_preserv_l; apply bound_stem_var.
+    + eapply Disjoint_Included_r; [|apply (IH e_arb e)]; eauto with Ensembles_DB; normalize_roundtrips.
+      split; auto.
+      erewrite <- (Setminus_Disjoint (bound_var _)); [|apply Disjoint_Singleton_r, H1].
+      apply Disjoint_Setminus_bal.
+      DisInc Hdis; eauto with Ensembles_DB.
+    + DisInc Hdis; eauto with Ensembles_DB.
+    + eauto with Ensembles_DB.
+  - intros x t n y C IH e_arb e [Huniq Hdis].
+    specialize (IH e_arb e); cbn in *.
+    revert Hdis; repeat (normalize_bound_var || normalize_occurs_free || normalize_bound_stem_ctx); intros Hdis;
+    inv Huniq; change (~ ?S ?x) with (~ x \in S) in *;
+    apply Union_Disjoint_l; apply Union_Disjoint_r; try solve [eauto with Ensembles_DB
+                                                              |DisInc Hdis; eauto with Ensembles_DB].
+    + rewrite bound_var_app_ctx in Hdis; DisInc Hdis; eauto with Ensembles_DB.
+      do 2 apply Included_Union_preserv_l; apply bound_stem_var.
+    + eapply Disjoint_Included_r; [|apply IH]; eauto with Ensembles_DB; normalize_roundtrips.
+      split; auto.
+      erewrite <- (Setminus_Disjoint (bound_var _)); [|apply Disjoint_Singleton_r, H1].
+      apply Disjoint_Setminus_bal.
+      DisInc Hdis; eauto with Ensembles_DB.
+  - intros x f ft ys C IH e_arb e [Huniq Hdis].
+    specialize (IH e_arb e); cbn in *.
+    revert Hdis; repeat (normalize_bound_var || normalize_occurs_free || normalize_bound_stem_ctx); intros Hdis;
+    inv Huniq; change (~ ?S ?x) with (~ x \in S) in *;
+    apply Union_Disjoint_l; apply Union_Disjoint_r; try solve [eauto with Ensembles_DB
+                                                              |DisInc Hdis; eauto with Ensembles_DB].
+    + rewrite bound_var_app_ctx in Hdis; DisInc Hdis; eauto with Ensembles_DB.
+      do 2 apply Included_Union_preserv_l; apply bound_stem_var.
+    + eapply Disjoint_Included_r; [|apply IH]; eauto with Ensembles_DB; normalize_roundtrips.
+      split; auto.
+      erewrite <- (Setminus_Disjoint (bound_var _)); [|apply Disjoint_Singleton_r, H1].
+      apply Disjoint_Setminus_bal.
+      DisInc Hdis; eauto with Ensembles_DB.
+  - intros x p ys C IH e_arb e [Huniq Hdis].
+    specialize (IH e_arb e); cbn in *.
+    revert Hdis; repeat (normalize_bound_var || normalize_occurs_free || normalize_bound_stem_ctx); intros Hdis;
+    inv Huniq; change (~ ?S ?x) with (~ x \in S) in *;
+    apply Union_Disjoint_l; apply Union_Disjoint_r; try solve [eauto with Ensembles_DB
+                                                              |DisInc Hdis; eauto with Ensembles_DB].
+    + rewrite bound_var_app_ctx in Hdis; DisInc Hdis; eauto with Ensembles_DB.
+      do 2 apply Included_Union_preserv_l; apply bound_stem_var.
+    + eapply Disjoint_Included_r; [|apply IH]; eauto with Ensembles_DB; normalize_roundtrips.
+      split; auto.
+      erewrite <- (Setminus_Disjoint (bound_var _)); [|apply Disjoint_Singleton_r, H1].
+      apply Disjoint_Setminus_bal.
+      DisInc Hdis; eauto with Ensembles_DB.
+  - intros x ces1 c C IH ces2 e_arb e [Huniq Hdis].
+    specialize (IH e_arb e); cbn in *.
+    revert Hdis; repeat (normalize_bound_var || normalize_occurs_free || normalize_bound_stem_ctx); intros Hdis.
+    rewrite unique_bindings_Ecase_app in Huniq.
+    destruct Huniq as [Huniq1 [Huniq2 Huniq3]].
+    inv Huniq2; change (~ ?S ?x) with (~ x \in S) in *.
+    apply Union_Disjoint_r; [|apply Union_Disjoint_r; [|apply Union_Disjoint_r]].
+    + rewrite bound_var_app_ctx in Hdis; DisInc Hdis; eauto with Ensembles_DB.
+      apply Included_Union_preserv_r; do 2 apply Included_Union_preserv_l; apply bound_stem_var.
+    + rewrite bound_var_app_ctx in Hdis; DisInc Hdis; eauto with Ensembles_DB.
+      apply Included_Union_preserv_r; do 2 apply Included_Union_preserv_l; apply bound_stem_var.
+    + eapply Disjoint_Included_r; [|apply IH]; eauto with Ensembles_DB; normalize_roundtrips.
+      split; auto. DisInc Hdis; eauto with Ensembles_DB.
+    + rewrite bound_var_app_ctx in Hdis; DisInc Hdis; eauto with Ensembles_DB.
+      apply Included_Union_preserv_r; do 2 apply Included_Union_preserv_l; apply bound_stem_var.
+  - intros fds C IH e_arb e [Huniq Hdis].
+    specialize (IH e_arb e); cbn in *.
+    revert Hdis; repeat (normalize_bound_var || normalize_occurs_free || normalize_bound_stem_ctx); intros Hdis;
+    inv Huniq; change (~ ?S ?x) with (~ x \in S) in *;
+    apply Union_Disjoint_l; apply Union_Disjoint_r; try solve [eauto with Ensembles_DB
+                                                              |DisInc Hdis; eauto with Ensembles_DB].
+    + rewrite bound_var_app_ctx in Hdis; DisInc Hdis; eauto with Ensembles_DB.
+      apply Included_Union_preserv_l; apply name_in_fundefs_bound_var_fundefs.
+    + rewrite bound_var_app_ctx in Hdis; DisInc Hdis; eauto with Ensembles_DB.
+      apply Included_Union_preserv_r, Included_Union_preserv_l, bound_stem_var.
+    + eapply Disjoint_Included_r; [|apply IH]; eauto with Ensembles_DB; normalize_roundtrips.
+      split; auto.
+      erewrite <- (Setminus_Disjoint (bound_var _) (name_in_fundefs fds)).
+      2: { DisInc H3; eauto with Ensembles_DB; apply name_in_fundefs_bound_var_fundefs. }
+      apply Disjoint_Setminus_bal.
+      DisInc Hdis; eauto with Ensembles_DB.
+  - intros C IH e e_arb e0 [Huniq Hdis]. cbn.
+    specialize (IH e_arb e0); cbn in *.
+    revert Hdis; repeat (normalize_bound_var || normalize_occurs_free || normalize_bound_stem_ctx); intros Hdis;
+    inv Huniq; change (~ ?S ?x) with (~ x \in S) in *;
+    apply Union_Disjoint_l; apply Union_Disjoint_r.
+    + eapply Disjoint_Union_l; apply IH; split; cbn; normalize_roundtrips; auto.
+      rewrite bound_var_app_f_ctx; apply Union_Disjoint_l;
+      rewrite bound_var_app_f_ctx in Hdis; DisInc Hdis; eauto with Ensembles_DB.
+    + rewrite <- name_in_fundefs_ctx_ctx; eauto with Ensembles_DB.
+    + eapply Disjoint_Union_r; apply IH; split; cbn; normalize_roundtrips; auto.
+      rewrite bound_var_app_f_ctx; apply Union_Disjoint_l;
+      rewrite bound_var_app_f_ctx in Hdis; DisInc Hdis; eauto with Ensembles_DB.
+    + rewrite <- name_in_fundefs_ctx_ctx in *; eauto with Ensembles_DB.
+      rewrite bound_var_app_f_ctx in Hdis; DisInc Hdis; eauto with Ensembles_DB.
+      do 2 apply Included_Union_preserv_l; apply bound_stem_var.
+  - intros f ft xs C IH fds e_arb e [Huniq Hdis].
+    specialize (IH e_arb e); cbn in *.
+    revert Hdis; repeat (normalize_bound_var || normalize_occurs_free || normalize_bound_stem_ctx); intros Hdis;
+    inv Huniq; change (~ ?S ?x) with (~ x \in S) in *.
+    repeat match goal with
+           | |- Disjoint _ (_ :|: _) _ => apply Union_Disjoint_l
+           | |- Disjoint _ _ (_ :|: _) => apply Union_Disjoint_r
+           end; eauto with Ensembles_DB.
+    + DisInc Hdis; eauto with Ensembles_DB.
+      do 3 apply Included_Union_preserv_r; apply name_in_fundefs_bound_var_fundefs.
+    + eapply Disjoint_Included_r; [|apply IH]; eauto with Ensembles_DB; split; auto.
+      erewrite <- (Setminus_Disjoint (bound_var _) (name_in_fundefs fds)).
+      2: { DisInc H8; eauto with Ensembles_DB; apply name_in_fundefs_bound_var_fundefs. }
+      erewrite <- (Setminus_Disjoint (bound_var _) (FromList xs)); auto.
+      erewrite <- (Setminus_Disjoint (bound_var _) [set f]); [|apply Disjoint_Singleton_r, H4].
+      rewrite !Setminus_Union; apply Disjoint_Setminus_bal.
+      DisInc Hdis; eauto with Ensembles_DB.
+    + rewrite bound_var_app_ctx in Hdis; DisInc Hdis; eauto with Ensembles_DB.
+      do 2 apply Included_Union_preserv_r; do 2 apply Included_Union_preserv_l; apply bound_stem_var.
+    + DisInc Hdis; eauto with Ensembles_DB.
+  - intros f ft xs e C IH e_arb e0 [Huniq Hdis].
+    specialize (IH e_arb e0); cbn in *.
+    revert Hdis; repeat (normalize_bound_var || normalize_occurs_free || normalize_bound_stem_ctx); intros Hdis;
+    inv Huniq; change (~ ?S ?x) with (~ x \in S) in *.
+    assert (Disjoint cps.var
+                     (bound_var_fundefs (ctx.app_f_ctx_f C e_arb))
+                     (occurs_free_fundefs (ctx.app_f_ctx_f C e_arb))). {
+      rewrite bound_var_app_f_ctx; apply Union_Disjoint_l.
+      * rewrite <- (Setminus_Disjoint (bound_var_fundefs_ctx _) [set f]).
+        2: { rewrite bound_var_app_f_ctx, Union_demorgan in H5.
+             destruct H5 as [H _]; apply Disjoint_Singleton_r in H; auto. }
+        apply Disjoint_Setminus_bal; DisInc Hdis; eauto with Ensembles_DB.
+        rewrite bound_var_app_f_ctx; eauto with Ensembles_DB.
+      * rewrite <- (Setminus_Disjoint (bound_var _) [set f]).
+        2: { rewrite bound_var_app_f_ctx, Union_demorgan in H5.
+             destruct H5 as [_ H]; apply Disjoint_Singleton_r in H; auto. }
+        apply Disjoint_Setminus_bal; DisInc Hdis; eauto with Ensembles_DB.
+        rewrite bound_var_app_f_ctx; eauto with Ensembles_DB. }
+    repeat match goal with
+           | |- Disjoint _ (_ :|: _) _ => apply Union_Disjoint_l
+           | |- Disjoint _ _ (_ :|: _) => apply Union_Disjoint_r
+           end; eauto with Ensembles_DB.
+    + rewrite <- name_in_fundefs_ctx_ctx in *. DisInc Hdis; eauto with Ensembles_DB.
+      rewrite bound_var_app_f_ctx.
+      do 3 apply Included_Union_preserv_r; apply Included_Union_preserv_l.
+      apply name_in_fundefs_ctx_bound_var_fundefs.
+    + eapply Disjoint_Included_l; [|eapply Disjoint_Included_r; [|apply IH]]; eauto with Ensembles_DB.
+      split; cbn; normalize_roundtrips; auto.
+    + rewrite <- name_in_fundefs_ctx_ctx in *; DisInc Hdis; eauto with Ensembles_DB.
+      rewrite bound_var_app_f_ctx; do 3 apply Included_Union_preserv_r.
+      apply Included_Union_preserv_l, bound_stem_var.
+    + eapply Disjoint_Included_l; [|eapply Disjoint_Included_r; [|apply IH]]; eauto with Ensembles_DB.
+      split; cbn; normalize_roundtrips; auto.
+Qed.
+
+Corollary stem_not_free c e_arb e :
+  well_scoped (ctx.app_ctx_f c e_arb) ->
+  Disjoint _ (bound_stem_ctx c) (occurs_free (ctx.app_ctx_f c e)).
+Proof. intros; eapply (proj1 stem_not_free_mut); eauto. Qed.
+
+Lemma name_in_fundefs_bound_var_fundefs_ctx : forall C : ctx.fundefs_ctx,
+  names_in_fundefs_ctx C \subset bound_var_fundefs_ctx C.
+Proof.
+  induction C.
+  - cbn; normalize_bound_var_ctx; eauto with Ensembles_DB.
+    pose (H := name_in_fundefs_bound_var_fundefs f); clearbody H.
+    eauto with Ensembles_DB.
+  - cbn; normalize_bound_var_ctx; eauto with Ensembles_DB.
+Qed.
+
+(* TODO: move to proto_util *)
+Lemma used_ces_vars_ces ces : used_ces ces <--> used_vars_ces ces.
+Proof. induction ces as [|[c e] ces IHces]; cbn; normalize_roundtrips; eauto with Ensembles_DB. Qed.
+
+Lemma used_c_vars_ces ces : used_c (c_of_ces ces) <--> used_ces ces.
+Proof.
+  induction ces as [|[c e] ces IHces]; cbn; normalize_roundtrips; eauto with Ensembles_DB.
+  change (fold_right _ _ _) with (c_of_ces ces).
+  rewrite used_c_comp, IHces; cbn; normalize_roundtrips; eauto with Ensembles_DB.
+Qed.
+
+Lemma used_c_of_ces_ctx : forall ces1 ct C ces2,
+  used_c (c_of_ces_ctx ces1 ct C ces2) <--> used_vars_ces ces1 :|: used_c [C]! :|: used_vars_ces ces2.
+Proof.
+  unfold c_of_ces_ctx, c_of_ces_ctx'; cbn; intros; rewrite !used_c_comp; cbn; normalize_sets.
+  rewrite used_c_vars_ces, !used_ces_vars_ces; cbn; split; eauto with Ensembles_DB.
+Qed.
+
+Lemma name_in_fundefs_c_of_fundefs C : names_in_fundefs_ctx C \subset used_c (c_of_fundefs_ctx C).
+Proof.
+  induction C; cbn; rewrite !used_c_comp; cbn; normalize_roundtrips; eauto with Ensembles_DB.
+  assert (name_in_fundefs f \subset used_vars_fundefs f). {
+    apply Included_Union_preserv_l, name_in_fundefs_bound_var_fundefs. }
+  apply Included_Union_preserv_l; normalize_sets; eauto with Ensembles_DB.
+Qed.
+
+(* TODO: move to Ensembles_util *)
+Lemma Disjoint_commut {A} S1 S2 : Disjoint A S1 S2 -> Disjoint A S2 S1.
+Proof. eauto with Ensembles_DB. Qed.
+
+Lemma Disjoint_Union {A} S1 S2 S3 :
+  Disjoint A S1 (S2 :|: S3) -> Disjoint A S1 S2 /\ Disjoint A S1 S3.
+Proof. eauto with Ensembles_DB. Qed.
+
+(* well_scoped(C[e]) ⟹ (BV(e) # vars(C)) ∧ (FV(e) ⊆ BVstem(C) ∪ FV(C[e]) *)
+Lemma well_scoped_mut' :
+  (forall (c : ctx.exp_ctx) (e : cps.exp),
+    well_scoped (ctx.app_ctx_f c e) ->
+    Disjoint _ (bound_var e) (used_c [c]!) /\
+    occurs_free e \subset bound_stem_ctx c :|: occurs_free (ctx.app_ctx_f c e)) /\
+  (forall (B : ctx.fundefs_ctx) (e : cps.exp),
+    well_scoped_fds (ctx.app_f_ctx_f B e) ->
+    Disjoint _ (bound_var e) (used_c [B]!) /\
+    occurs_free e \subset name_in_fundefs (ctx.app_f_ctx_f B e)
+                :|: bound_stem_fundefs_ctx B :|: occurs_free_fundefs (ctx.app_f_ctx_f B e)).
+Proof.
+  apply ctx.exp_fundefs_ctx_mutual_ind; unfold well_scoped.
+  - cbn; normalize_roundtrips; intros; eauto with Ensembles_DB.
+  - intros x c ys C IH e [Huniq Hdis]; specialize (IH e).
+    cbn in *; rewrite !used_c_comp; cbn; inv Huniq.
+    revert Hdis; repeat (normalize_bound_var || normalize_occurs_free
+                         || normalize_sets || normalize_roundtrips); intros Hdis.
+    destruct IH as [IHdis IHfv]; [split; eauto|split].
+    { apply Disjoint_Union in Hdis; destruct Hdis as [Hdis1 Hdis2].
+      apply Disjoint_commut, Disjoint_Union in Hdis2; destruct Hdis2 as [Hdis2 _].
+      eapply Disjoint_Included_r; [apply Included_Union_Setminus
+                                  |apply Union_Disjoint_r; [apply Disjoint_commut, Hdis2|]];
+      eauto with Decidable_DB Ensembles_DB. }
+    + apply Union_Disjoint_r; [apply Union_Disjoint_r|apply IHdis].
+      * change (~ ?S ?x) with (~ x \in S) in *.
+        rewrite bound_var_app_ctx, Union_demorgan in H1.
+        now apply Disjoint_Singleton_r.
+      * rewrite bound_var_app_ctx in *.
+        eapply Disjoint_Included_l; [|eapply Disjoint_Included_r; [|apply Hdis]]; eauto with Ensembles_DB.
+    + normalize_bound_stem_ctx; eapply Included_trans; [apply IHfv|].
+      apply Union_Included; eauto with Ensembles_DB.
+      repeat rewrite <- Union_assoc; apply Included_Union_preserv_r.
+      rewrite Union_assoc, (Union_commut [set x]), <- Union_assoc; apply Included_Union_preserv_r.
+      rewrite Union_commut; apply Included_Union_Setminus; eauto with Decidable_DB.
+  - intros x t n y C IH e [Huniq Hdisj]; specialize (IH e).
+    cbn in *; rewrite !used_c_comp; cbn; inv Huniq.
+    revert Hdisj; repeat (normalize_bound_var || normalize_occurs_free
+                          || normalize_sets || normalize_roundtrips); intros Hdisj.
+    destruct IH as [IHdisj IHfv]; [split; auto|split].
+    { apply Disjoint_Union in Hdisj; destruct Hdisj as [Hdisj1 Hdisj2].
+      apply Disjoint_commut, Disjoint_Union in Hdisj2; destruct Hdisj2 as [Hdisj2 _].
+      eapply Disjoint_Included_r; [apply Included_Union_Setminus
+                                  |apply Union_Disjoint_r; [apply Disjoint_commut, Hdisj2|]];
+      eauto with Decidable_DB Ensembles_DB. }
+    + apply Union_Disjoint_r; [apply Union_Disjoint_r|apply IHdisj].
+      * change (~ ?S ?x) with (~ x \in S) in *.
+        rewrite bound_var_app_ctx, Union_demorgan in H1.
+        now apply Disjoint_Singleton_r.
+      * rewrite bound_var_app_ctx in *.
+        eapply Disjoint_Included_l; [|eapply Disjoint_Included_r; [|apply Hdisj]]; eauto with Ensembles_DB.
+    + normalize_bound_stem_ctx; eapply Included_trans; [apply IHfv|].
+      apply Union_Included; eauto with Ensembles_DB.
+      repeat rewrite <- Union_assoc; apply Included_Union_preserv_r.
+      rewrite Union_assoc, (Union_commut [set x]), <- Union_assoc; apply Included_Union_preserv_r.
+      rewrite Union_commut; apply Included_Union_Setminus; eauto with Decidable_DB.
+  - intros x f ft ys C IH e [Huniq Hdisj]; specialize (IH e).
+    cbn in *; rewrite !used_c_comp; cbn; inv Huniq.
+    revert Hdisj; repeat (normalize_bound_var || normalize_occurs_free
+                          || normalize_sets || normalize_roundtrips); intros Hdisj.
+    destruct IH as [IHdisj IHfv]; [split; auto|split].
+    { apply Disjoint_Union in Hdisj; destruct Hdisj as [Hdisj1 Hdisj2].
+      apply Disjoint_commut, Disjoint_Union in Hdisj2; destruct Hdisj2 as [Hdisj2 _].
+      eapply Disjoint_Included_r; [apply Included_Union_Setminus
+                                  |apply Union_Disjoint_r; [apply Disjoint_commut, Hdisj2|]];
+      eauto with Decidable_DB Ensembles_DB. }
+    + apply Union_Disjoint_r; [apply Union_Disjoint_r|apply IHdisj].
+      * change (~ ?S ?x) with (~ x \in S) in *.
+        rewrite bound_var_app_ctx, Union_demorgan in H1.
+        now apply Disjoint_Singleton_r.
+      * rewrite bound_var_app_ctx in *.
+        eapply Disjoint_Included_l; [|eapply Disjoint_Included_r; [|apply Hdisj]]; eauto with Ensembles_DB.
+    + normalize_bound_stem_ctx; eapply Included_trans; [apply IHfv|].
+      apply Union_Included; eauto with Ensembles_DB.
+      repeat rewrite <- Union_assoc; apply Included_Union_preserv_r.
+      rewrite Union_assoc, (Union_commut [set x]), <- Union_assoc, (Union_assoc [set x]), (Union_commut [set x]),
+        <- Union_assoc.
+      do 2 apply Included_Union_preserv_r.
+      rewrite Union_commut; apply Included_Union_Setminus; eauto with Decidable_DB.
+  - intros x p ys C IH e [Huniq Hdisj]; specialize (IH e).
+    cbn in *; rewrite !used_c_comp; cbn; inv Huniq.
+    revert Hdisj; repeat (normalize_bound_var || normalize_occurs_free
+                          || normalize_sets || normalize_roundtrips); intros Hdisj.
+    destruct IH as [IHdisj IHfv]; [split; auto|split].
+    { apply Disjoint_Union in Hdisj; destruct Hdisj as [Hdisj1 Hdisj2].
+      apply Disjoint_commut, Disjoint_Union in Hdisj2; destruct Hdisj2 as [Hdisj2 _].
+      eapply Disjoint_Included_r; [apply Included_Union_Setminus
+                                  |apply Union_Disjoint_r; [apply Disjoint_commut, Hdisj2|]];
+      eauto with Decidable_DB Ensembles_DB. }
+    + apply Union_Disjoint_r; [apply Union_Disjoint_r|apply IHdisj].
+      * change (~ ?S ?x) with (~ x \in S) in *.
+        rewrite bound_var_app_ctx, Union_demorgan in H1.
+        now apply Disjoint_Singleton_r.
+      * rewrite bound_var_app_ctx in *.
+        eapply Disjoint_Included_l; [|eapply Disjoint_Included_r; [|apply Hdisj]]; eauto with Ensembles_DB.
+    + normalize_bound_stem_ctx; eapply Included_trans; [apply IHfv|].
+      apply Union_Included; eauto with Ensembles_DB.
+      repeat rewrite <- Union_assoc; apply Included_Union_preserv_r.
+      rewrite Union_assoc, (Union_commut [set x]), <- Union_assoc; apply Included_Union_preserv_r.
+      rewrite Union_commut; apply Included_Union_Setminus; eauto with Decidable_DB.
+  - intros x ces1 ct C IH ces2 e [Huniq Hdisj]; specialize (IH e).
+    cbn in *; rewrite !used_c_comp; cbn.
+    revert Hdisj; repeat (normalize_bound_var || normalize_occurs_free
+                          || normalize_sets || normalize_roundtrips); intros Hdisj.
+    destruct IH as [IHdisj IHfv]; [split; auto|split].
+    { rewrite unique_bindings_Ecase_app in Huniq; decompose [and] Huniq; clear Huniq.
+      inv H1; auto. }
+    { apply Disjoint_Union in Hdisj; destruct Hdisj as [Hdisj1 Hdisj2].
+      eapply Disjoint_Included_l; [|eapply Disjoint_Included_r; [|apply Hdisj2]]; eauto with Ensembles_DB. }
+    + rewrite unique_bindings_Ecase_app in Huniq; decompose [and] Huniq; clear Huniq.
+      inv H1. rewrite used_c_of_ces_ctx; cbn.
+      repeat match goal with |- Disjoint _ _ (_ :|: _) => apply Union_Disjoint_r end; auto.
+      * rewrite bound_var_app_ctx in Hdisj.
+        eapply Disjoint_Included_l; [|eapply Disjoint_Included_r; [|apply Hdisj]]; eauto with Ensembles_DB. 
+      * rewrite used_vars_ces_bv_fv. apply Union_Disjoint_r.
+        -- normalize_bound_var_in_ctx; rewrite !bound_var_Ecase, bound_var_app_ctx in H2.
+           apply Disjoint_commut; eapply Disjoint_Included_r; [|eassumption]; eauto with Ensembles_DB.
+        -- rewrite occurs_free_Ecase, bound_var_app_ctx in Hdisj.
+           eapply Disjoint_Included_l; [|eapply Disjoint_Included_r; [|apply Hdisj]]; eauto with Ensembles_DB. 
+      * rewrite used_vars_ces_bv_fv. apply Union_Disjoint_r.
+        -- rewrite bound_var_app_ctx, bound_var_Ecase in H8. eauto with Ensembles_DB.
+        -- rewrite bound_var_app_ctx, !occurs_free_Ecase in Hdisj.
+           eapply Disjoint_Included_l; [|eapply Disjoint_Included_r; [|apply Hdisj]]; eauto with Ensembles_DB. 
+    + normalize_bound_stem_ctx; eapply Included_trans; [apply IHfv|]; eauto with Ensembles_DB.
+  - intros fds C IH e [Huniq Hdisj]; specialize (IH e).
+    cbn in *; rewrite !used_c_comp; cbn.
+    revert Hdisj; repeat (normalize_bound_var || normalize_occurs_free
+                          || normalize_sets || normalize_roundtrips); intros Hdisj.
+    destruct IH as [IHdisj IHfv]; [split; auto|split].
+    { now inv Huniq. }
+    { inv Huniq. eapply Disjoint_Included_r;
+                   [apply Included_Union_Setminus with (s2 := name_in_fundefs fds); eauto with Decidable_DB|].
+      apply Union_Disjoint_r;
+        [eapply Disjoint_Included_l; [|eapply Disjoint_Included_r; [|apply Hdisj]]|]; eauto with Ensembles_DB.
+      eapply Disjoint_Included_r; [apply name_in_fundefs_bound_var_fundefs|]; auto. }
+    + apply Union_Disjoint_r; [apply Union_Disjoint_r|apply IHdisj].
+      * inv Huniq. rewrite bound_var_app_ctx in H3; eauto with Ensembles_DB.
+      * eapply Disjoint_Included_l; [|eapply Disjoint_Included_r; [|apply Hdisj]]; eauto with Ensembles_DB.
+        rewrite bound_var_app_ctx; eauto with Ensembles_DB.
+    + normalize_bound_stem_ctx; eapply Included_trans; [apply IHfv|].
+      apply Union_Included; eauto with Ensembles_DB.
+      rewrite (Union_commut (name_in_fundefs _)), <- Union_assoc.
+      rewrite (Union_assoc (name_in_fundefs _)), (Union_commut (name_in_fundefs _)), <- Union_assoc.
+      do 2 apply Included_Union_preserv_r; rewrite Union_commut.
+      apply Included_Union_Setminus; eauto with Decidable_DB.
+  - intros C IH e1 e [Huniq Hdisj]; specialize (IH e).
+    cbn in *; rewrite !used_c_comp; cbn.
+    revert Hdisj; repeat (normalize_bound_var || normalize_occurs_free || normalize_roundtrips
+                          || normalize_sets || normalize_roundtrips); intros Hdisj.
+    destruct IH as [IHdisj IHfv]; [split; auto|split].
+    { cbn; normalize_roundtrips; now inv Huniq. }
+    { cbn; normalize_roundtrips.
+      eapply Disjoint_Included_l; [|eapply Disjoint_Included_r; [|apply Hdisj]]; eauto with Ensembles_DB. }
+    + apply Union_Disjoint_r; [apply Union_Disjoint_r|apply IHdisj].
+      * inv Huniq. rewrite bound_var_app_f_ctx in H3; eauto with Ensembles_DB.
+      * rewrite bound_var_app_f_ctx in *.
+        eapply Disjoint_Included_r; [apply Included_Union_Setminus with
+                                         (s2 := name_in_fundefs (ctx.app_f_ctx_f C e))|]; eauto with Decidable_DB.
+        apply Union_Disjoint_r.
+        -- eapply Disjoint_Included_l; [|eapply Disjoint_Included_r; [|apply Hdisj]]; eauto with Ensembles_DB.
+        -- rewrite <- name_in_fundefs_ctx_ctx.
+           eapply Disjoint_Included_r; [apply name_in_fundefs_c_of_fundefs|]; auto.
+    + normalize_bound_stem_ctx; eapply Included_trans; [apply IHfv|].
+      apply Union_Included; eauto with Ensembles_DB.
+      apply Union_Included; eauto with Ensembles_DB.
+      rewrite name_in_fundefs_ctx_ctx; eauto with Ensembles_DB.
+  - intros f ft xs C IH fds e [Huniq Hdisj]. specialize (IH e); cbn in *; normalize_roundtrips.
+    rewrite !used_c_comp; cbn.
+    revert Hdisj; repeat (normalize_bound_var || normalize_occurs_free || normalize_roundtrips
+                          || normalize_sets || normalize_roundtrips); intros Hdisj.
+    destruct IH as [IHdisj IHfv]; [split; auto|split].
+    { now inv Huniq. }
+    { inv Huniq. change (~ ?S ?x) with (~ x \in S) in *.
+      erewrite <- (Setminus_Disjoint (bound_var (ctx.app_ctx_f C e)));
+        [|eapply Disjoint_Included_r; [apply name_in_fundefs_bound_var_fundefs|]; apply H8].
+      erewrite <- (Setminus_Disjoint (bound_var (ctx.app_ctx_f C e))); [|apply H6].
+      erewrite <- (Setminus_Disjoint (bound_var (ctx.app_ctx_f C e))); [|apply Disjoint_Singleton_r, H4].
+      rewrite !Setminus_Union.
+      apply Disjoint_Setminus_bal.
+      eapply Disjoint_Included_l; [|eapply Disjoint_Included_r; [|apply Hdisj]]; eauto with Ensembles_DB. }
+    + apply Union_Disjoint_r; [apply Union_Disjoint_r; [|apply Union_Disjoint_r]|apply IHdisj].
+      * assert (Hnof : Disjoint _ (bound_var e) [set f]). {
+          inv Huniq. change (~ ?S ?x) with (~ x \in S) in *.
+          rewrite bound_var_app_ctx, Union_demorgan in H4.
+          now apply Disjoint_Singleton_r. }
+        apply Union_Disjoint_r; [apply Hnof|].
+        inv Huniq; rewrite bound_var_app_ctx in H6; now apply Disjoint_Union_r in H6.
+      * inv Huniq; rewrite bound_var_app_ctx in H8; now apply Disjoint_Union_r in H8.
+      * assert (Hnof : bound_var e \subset bound_var e \\ [set f]). {
+          intros arb Harb; constructor; auto.
+          inv Huniq. intros Hc; inv Hc. apply H4. change (?S ?x) with (x \in S).
+          rewrite bound_var_app_ctx; now right. }
+        eapply Disjoint_Included_l; [apply Hnof|].
+        apply Disjoint_Setminus_bal.
+        DisInc Hdisj; rewrite ?bound_var_app_ctx; eauto with Ensembles_DB.
+    + normalize_bound_stem_ctx; eapply Included_trans; [apply IHfv|].
+      apply Union_Included; eauto with Ensembles_DB.
+      eapply Included_trans with (s2 :=
+        (f |: FromList xs :|: name_in_fundefs fds) :|: 
+        (occurs_free (ctx.app_ctx_f C e) \\ (f |: (FromList xs :|: name_in_fundefs fds)))).
+      2: eauto with Ensembles_DB.
+      rewrite Union_commut, <- !Union_assoc.
+      apply Included_Union_Setminus; eauto with Decidable_DB.
+  - intros f ft xs e C IH e0 [Huniq Hdisj]; specialize (IH e0).
+    cbn in *; rewrite !used_c_comp; cbn.
+    revert Hdisj; repeat (normalize_bound_var || normalize_occurs_free || normalize_roundtrips
+                          || normalize_sets || normalize_roundtrips); intros Hdisj.
+    destruct IH as [IHdisj IHfv]; [split; auto|split].
+    { cbn; normalize_roundtrips; now inv Huniq. }
+    { inv Huniq; cbn in *; normalize_roundtrips. change (~ ?S ?x) with (~ x \in S) in *.
+      erewrite <- (Setminus_Disjoint (bound_var_fundefs (ctx.app_f_ctx_f C e0))); [|apply Disjoint_Singleton_r, H5].
+      apply Disjoint_Setminus_bal.
+      eapply Disjoint_Included_l; [|eapply Disjoint_Included_r; [|apply Hdisj]]; eauto with Ensembles_DB. }
+    { apply Union_Disjoint_r; eauto with Ensembles_DB.
+      inv Huniq. change (~ ?S ?x) with (~ x \in S) in *. rewrite bound_var_app_f_ctx in *.
+      rewrite Union_demorgan in H5; destruct H5 as [HC He0].
+      apply Union_Disjoint_r; [apply Union_Disjoint_r; [apply Disjoint_Singleton_r in He0; apply He0|]|];
+       eauto with Ensembles_DB; apply Union_Disjoint_r; eauto with Ensembles_DB.
+      rewrite <- (Setminus_Disjoint (bound_var e0) (name_in_fundefs (ctx.app_f_ctx_f C e0))).
+      2: { eapply Disjoint_Included_r; [rewrite <- name_in_fundefs_ctx_ctx; apply Included_refl|].
+           eapply Disjoint_Included_r; [apply name_in_fundefs_bound_var_fundefs_ctx|].
+           rewrite (proj2 (ub_app_ctx_f e0)) in H12; decompose [and] H12.
+           eauto with Ensembles_DB. }
+      erewrite <- (Setminus_Disjoint (bound_var e0) (FromList xs)); eauto with Ensembles_DB. 
+      erewrite <- (Setminus_Disjoint (bound_var e0)); [|apply Disjoint_Singleton_r, He0].
+      rewrite !Setminus_Union.
+      apply Disjoint_Setminus_bal.
+      eapply Disjoint_Included_l; [|eapply Disjoint_Included_r; [|apply Hdisj]]; eauto with Ensembles_DB. }
+    + normalize_bound_stem_ctx; eapply Included_trans; [apply IHfv|].
+      apply Union_Included; eauto with Ensembles_DB.
+      eapply Included_trans with (s2 := (f |: (occurs_free_fundefs (ctx.app_f_ctx_f C e0) \\ [set f]))).
+      2: eauto with Ensembles_DB.
+      rewrite Union_commut.
+      apply Included_Union_Setminus; eauto with Decidable_DB.
+Qed.
+
+(* TODO move to proto_util *)
+Lemma bound_vars_used_c_mut :
+  (forall (c : ctx.exp_ctx) (e : cps.exp),
+    bound_var_ctx c \subset used_c [c]!) /\
+  (forall (B : ctx.fundefs_ctx) (e : cps.exp),
+    bound_var_fundefs_ctx B \subset used_c [B]!).
+Proof.
+  apply ctx.exp_fundefs_ctx_mutual_ind; intros;
+    repeat normalize_bound_var_ctx; cbn in *;
+    repeat normalize_sets; eauto with Ensembles_DB;
+    rewrite ?used_c_comp in *; cbn; normalize_roundtrips; repeat normalize_sets;
+    match goal with H : cps.exp -> _ |- _ => specialize (H (cps.Ehalt 1))%positive end;
+    eauto with Ensembles_DB.
+  - rewrite used_c_of_ces_ctx; cbn; rewrite !bound_var_Ecase, !used_vars_ces_bv_fv.
+    repeat apply Union_Included; eauto with Ensembles_DB.
+  - unfold used_vars_fundefs; repeat apply Union_Included; eauto with Ensembles_DB.
+  - unfold used_vars; repeat apply Union_Included; eauto with Ensembles_DB.
+Qed.
+Corollary bound_vars_used_c c : bound_var_ctx c \subset used_c [c]!.
+Proof. apply (proj1 bound_vars_used_c_mut c (cps.Ehalt 1%positive)). Qed.
+Corollary bound_fds_used_c c : bound_var_fundefs_ctx c \subset used_c [c]!.
+Proof. apply (proj2 bound_vars_used_c_mut c (cps.Ehalt 1%positive)). Qed.
+
+Lemma well_scoped_inv c e :
+  well_scoped (ctx.app_ctx_f c e) ->
+  well_scoped e.
+Proof.
+  intros Hscope; pose (Hscope' := Hscope); clearbody Hscope';
+  apply (proj1 well_scoped_mut') in Hscope'; destruct Hscope as [Huniq Hdis], Hscope' as [Hbv Hfv].
+  split.
+  - rewrite (proj1 (ub_app_ctx_f _)) in Huniq; now decompose [and] Huniq.
+  - eapply Disjoint_Included_r; [apply Hfv|]; apply Union_Disjoint_r.
+    + rewrite (proj1 (ub_app_ctx_f _)) in Huniq; destruct Huniq as [HuniqC [Huniqe HdisCe]].
+      eapply Disjoint_Included_r; [|apply Hbv].
+      eapply Included_trans; [apply bound_stem_var|]; apply bound_vars_used_c.
+    + eapply Disjoint_Included_l; [|apply Hdis].
+      rewrite bound_var_app_ctx; eauto with Ensembles_DB.
+Qed.
+
+Lemma well_scoped_fv c e :
+  well_scoped (ctx.app_ctx_f c e) ->
+  occurs_free e \subset bound_stem_ctx c :|: occurs_free (ctx.app_ctx_f c e).
+Proof. apply well_scoped_mut'. Qed.

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -115,6 +115,12 @@ L4_deBruijn/toplevel.v
 #L5_CPS/cpseval.v
 
 # L6
+L6_PCPS/Frame.v
+L6_PCPS/Rewriting.v
+L6_PCPS/PrototypeGenFrame.v
+L6_PCPS/Prototype.v
+L6_PCPS/MockExpr.v
+L6_PCPS/PrototypeTests.v
 L6_PCPS/Ensembles_util.v
 L6_PCPS/tactics.v
 L6_PCPS/List_util.v
@@ -125,6 +131,8 @@ L6_PCPS/cps.v
 L6_PCPS/ctx.v
 L6_PCPS/cps_util.v
 L6_PCPS/identifiers.v
+L6_PCPS/cps_proto.v
+L6_PCPS/proto_util.v
 L6_PCPS/rename.v
 L6_PCPS/size_cps.v
 L6_PCPS/eval.v

--- a/theories/_CoqProject
+++ b/theories/_CoqProject
@@ -161,6 +161,7 @@ L6_PCPS/closure_conversion_invariants.v
 #L6_PCPS/closure_conversion_corresp.v
 L6_PCPS/shrink_cps.v
 L6_PCPS/shrink_cps_correct.v
+L6_PCPS/scoping.v
 # L6_PCPS/shrink_cps_corresp.v
 L6_PCPS/uncurry.v
 L6_PCPS/uncurry_correct.v


### PR DESCRIPTION
This includes the MetaCoq needed to generate 1-hole contexts from inductive types and rewriters from their specifications. It also includes a few useful lemmas about name binding.