### PR TITLE
Fixed a bug in erasure of primitive projection types in metacoq (no e…

### DIFF
--- a/plugin/certicoq.ml
+++ b/plugin/certicoq.ml
@@ -85,7 +85,7 @@ Valid options:\n\
 -direct   :  Produce direct-style code (as opposed to he default which is continuation-passing style)\n\
 -time     :  Time each compilation phase\n\
 -O n      :  Perform more aggressive optimizations. 1: lambda lifting for closure environment unboxing, 2: lambda lifting and inling for lambda lifting shells\n\
--bebug    :  Show debugging information\n\
+-debug    :  Show debugging information\n\
 -args X   :  Specify how many arguments are used in the C translation (on top of the thread_info argument)\n\
 -ext S    :  Specify the string s to be appended to the file name\n\
 -prefix S :  Specify the string s to be prepended to the FFI functions (to avoid clashes with C functions)\n\

--- a/plugin/certicoq_plugin.mllib
+++ b/plugin/certicoq_plugin.mllib
@@ -4,7 +4,6 @@ AstUtils
 Basics
 BinInt
 Char0
-DecidableClass
 Errors0
 FMapPositive
 FLT


### PR DESCRIPTION
…rasure needed actually)

Bump submodule and also fix a minor issue in the .mllib and a typo in the help message of CertiCoq Compile