### PR TITLE
New glue vernacular command

### DIFF
--- a/benchmarks/tests.v
+++ b/benchmarks/tests.v
@@ -13,6 +13,8 @@ Import VeriStar.
 
 CertiCoq -help.
 
+CertiCoq Generate Glue -file "basics" [ nat, list, bool ].
+
 (* Demo 1 *)
 
 Definition demo1 := List.app (List.repeat true 500) (List.repeat false 300).

--- a/plugin/certicoq.ml
+++ b/plugin/certicoq.ml
@@ -29,6 +29,10 @@ let chars_of_string (s : string) : char list =
     if i < 0 then l else exp (i - 1) (s.[i] :: l) in
   exp (String.length s - 1) []
 
+(* remove duplicates but preserve order, keep the leftmost element *)
+let nub (xs : 'a list) : 'a list = 
+  List.fold_right (fun x xs -> if List.mem x xs then xs else x :: xs) xs []
+
 let rec coq_nat_of_int x =
   match x with
   | 0 -> Datatypes.O
@@ -174,12 +178,15 @@ let compile opts term imports =
     CErrors.user_err ~hdr:"pipeline" (str "Could not compile: " ++ (pr_char_list s) ++ str "\n")
 
 (* Generate glue code for the compiled program *)
-let generate_glue opts term =
+let generate_glue (standalone : bool) opts globs =
+  if standalone && opts.filename = "" then
+    CErrors.user_err ~hdr:"glue-code" (str "You need to provide a file name with the -file option.")
+  else
   let debug = opts.debug in
   let options = make_pipeline_options opts in
 
   let time = Unix.gettimeofday() in
-  (match Pipeline.make_glue options term with
+  (match Pipeline.make_glue options globs with
   | CompM.Ret (((nenv, header), prg), logs) ->
     let time = (Unix.gettimeofday() -. time) in
     debug_msg debug (Printf.sprintf "Generated glue code in %f s.." time);
@@ -188,8 +195,8 @@ let generate_glue opts term =
     let time = Unix.gettimeofday() in
     let suff = opts.ext in
     let fname = opts.filename in
-    let cstr = "glue." ^ fname ^ suff ^ ".c" in
-    let hstr = "glue." ^ fname ^ suff ^ ".h" in
+    let cstr = if standalone then fname ^ ".c" else "glue." ^ fname ^ suff ^ ".c" in
+    let hstr = if standalone then fname ^ ".h" else "glue." ^ fname ^ suff ^ ".h" in
     printProg prg nenv cstr [];
     printProg header nenv hstr [];
 
@@ -202,7 +209,7 @@ let generate_glue opts term =
 let compile_with_glue (opts : options) (gr : Names.GlobRef.t) (imports : string list) : unit =
   let term = quote opts gr in
   compile opts (Obj.magic term) imports;
-  generate_glue opts (Obj.magic term)
+  generate_glue false opts (fst (Obj.magic term))
 
 let compile_only opts gr imports =
   let term = quote opts gr in
@@ -210,7 +217,7 @@ let compile_only opts gr imports =
 
 let generate_glue_only opts gr =
   let term = quote opts gr in
-  generate_glue opts (Obj.magic term)
+  generate_glue true opts (fst (Obj.magic term))
 
 let print_to_file (s : string) (file : string) =
   let f = open_out file in
@@ -282,3 +289,9 @@ let ffi_command opts gr =
     debug_msg debug (Printf.sprintf "Printed FFI glue code to file in %f s.." time)
   | CompM.Err s ->
     CErrors.user_err ~hdr:"ffi-glue-code" (str "Could not generate FFI glue code: " ++ pr_char_list s))
+
+let glue_command opts grs =
+  let terms = grs |> List.rev
+              |> List.map (fun gr -> fst (quote opts gr)) 
+              |> List.concat |> nub in
+  generate_glue true opts (Obj.magic terms)

--- a/plugin/certicoq.ml
+++ b/plugin/certicoq.ml
@@ -186,7 +186,7 @@ let generate_glue (standalone : bool) opts globs =
   let options = make_pipeline_options opts in
 
   let time = Unix.gettimeofday() in
-  (match Pipeline.make_glue options globs with
+  (match Glue.generate_glue options globs with
   | CompM.Ret (((nenv, header), prg), logs) ->
     let time = (Unix.gettimeofday() -. time) in
     debug_msg debug (Printf.sprintf "Generated glue code in %f s.." time);
@@ -272,7 +272,7 @@ let ffi_command opts gr =
   let options = make_pipeline_options opts in
 
   let time = Unix.gettimeofday() in
-  (match Pipeline.make_ffi options (Obj.magic term) with
+  (match Ffi.generate_ffi options (Obj.magic term) with
   | CompM.Ret (((nenv, header), prg), logs) ->
     let time = (Unix.gettimeofday() -. time) in
     debug_msg debug (Printf.sprintf "Generated FFI glue code in %f s.." time);

--- a/plugin/certicoq.mli
+++ b/plugin/certicoq.mli
@@ -36,3 +36,4 @@ val compile_only : options -> Names.GlobRef.t -> string list -> unit
 val generate_glue_only : options -> Names.GlobRef.t -> unit
 val show_ir : options -> Names.GlobRef.t -> unit
 val ffi_command : options -> Names.GlobRef.t -> unit
+val glue_command : options -> Names.GlobRef.t list -> unit

--- a/plugin/g_certicoq.mlg
+++ b/plugin/g_certicoq.mlg
@@ -37,6 +37,13 @@ VERNAC ARGUMENT EXTEND ffiargs
 | [ cargs(c) ] -> { c }
 END
 
+VERNAC ARGUMENT EXTEND glueargs
+| [ "-cps" ] -> { CPS }
+| [ "-debug" ] -> { DEBUG }
+| [ "-args" natural(n) ] -> { ARGS(n) }
+| [ "-file" string(s) ] -> { FILENAME(s) }
+END
+
 VERNAC COMMAND EXTEND CertiCoq_Compile CLASSIFIED AS QUERY
 | [ "CertiCoq" "Compile" cargs_list(l) global(gr) ] -> {
     let gr = Nametab.global gr in
@@ -62,6 +69,11 @@ VERNAC COMMAND EXTEND CertiCoq_Compile CLASSIFIED AS QUERY
     let gr = Nametab.global gr in
     let opts = Certicoq.make_options l [] (get_name gr) in
     Certicoq.ffi_command opts gr
+  }
+| [ "CertiCoq" "Generate" "Glue" glueargs_list(l) "[" global_list_sep(grs, ",") "]" ] -> {
+    let grs = List.map Nametab.global grs in
+    let opts = Certicoq.make_options l [] "" in
+    Certicoq.glue_command opts grs
   }
 | [ "CertiCoq" "-help" ] -> {
     Feedback.msg_info (str help_msg)

--- a/plugin/g_certicoq.mlg
+++ b/plugin/g_certicoq.mlg
@@ -67,7 +67,7 @@ VERNAC COMMAND EXTEND CertiCoq_Compile CLASSIFIED AS QUERY
   }
 | [ "CertiCoq" "FFI" ffiargs_list(l) global(gr) ] -> {
     let gr = Nametab.global gr in
-    let opts = Certicoq.make_options l [] (get_name gr) in
+    let opts = Certicoq.make_options l [] "" in
     Certicoq.ffi_command opts gr
   }
 | [ "CertiCoq" "Generate" "Glue" glueargs_list(l) "[" global_list_sep(grs, ",") "]" ] -> {

--- a/theories/Compiler/pipeline.v
+++ b/theories/Compiler/pipeline.v
@@ -167,26 +167,3 @@ Definition show_IR (opts : Options) (p : Template.Ast.program) : (error string *
     (Ret (cps_show.show_exp nenv cenv false e), log)
   | Err s => (Err s, log)
   end.
-
-
-(** * Glue Code *)
-
-Definition make_glue (opts : Options) (globs : Template.Ast.global_env)
-  : error (cps_util.name_env * Clight.program * Clight.program * list string)  :=
-  match generate_glue opts globs with
-  | Ret (nenv, Some hdr, Some prg, logs) =>
-      Ret (nenv, hdr, prg, logs)
-  | Ret (nenv, _, _, logs) =>
-      Err "No Clight program generated"
-  | Err s => Err s
-  end.
-
-Definition make_ffi (opts : Options) (p : Template.Ast.program)
-  : error (cps_util.name_env * Clight.program * Clight.program * list string)  :=
-  match generate_ffi opts p with
-  | Ret (nenv, Some hdr, Some prg, logs) =>
-      Ret (nenv, hdr, prg, logs)
-  | Ret (nenv, _, _, logs) =>
-      Err "No Clight program generated"
-  | Err s => Err s
-  end.

--- a/theories/Extraction/extraction.v
+++ b/theories/Extraction/extraction.v
@@ -90,8 +90,8 @@ Separate Extraction
          String.length
          Compiler.pipeline.make_opts
          Compiler.pipeline.compile
-         Compiler.pipeline.make_glue
-         Compiler.pipeline.make_ffi
+         Glue.glue.generate_glue
+         Glue.ffi.generate_ffi
          cps.M.elements
          Compiler.pipeline.show_IR.
 

--- a/theories/Glue/ffi.v
+++ b/theories/Glue/ffi.v
@@ -442,7 +442,7 @@ Definition get_constructors
 Definition generate_ffi
            (opts : Options)
            (p : Ast.program)
-           : error (name_env * option Clight.program * option Clight.program * list string) :=
+           : error (name_env * Clight.program * Clight.program * list string) :=
   let init : fstate_data :=
       {| fstate_gensym := 2%positive
        ; fstate_nenv   := M.empty _
@@ -452,10 +452,11 @@ Definition generate_ffi
       runState ((get_constructors >=> make_ffi_program) p) opts init in
   let nenv := fstate_nenv st in
   match err with
-  | Ret (header, source) =>
+  | Err s => Err s
+  | Ret (Some header, Some source) =>
     Ret (nenv (* the name environment to be passed to C generation *) ,
          header (* the header content *),
          source (* the source content *),
          rev (fstate_log st) (* logged messages *))
-  | Err s => Err s
+  | Ret _ => Err "No Clight program generated"
   end.

--- a/theories/Glue/glue.v
+++ b/theories/Glue/glue.v
@@ -796,11 +796,11 @@ Section CtorArrays.
         (max_len, i ++ init_l)
     end.
 
-  Fixpoint make_name_array
-           (tag : ind_L1_tag)
-           (kn : kername)
-           (ctors : list (BasicAst.ident * Ast.term * nat))
-           : glueM def :=
+  Definition make_name_array
+             (tag : ind_L1_tag)
+             (kn : kername)
+             (ctors : list (BasicAst.ident * Ast.term * nat))
+             : glueM def :=
     let (max_len, init_l) := normalized_names_array ctors 1 in
     let ty := tarray (tarray tschar (Z.of_nat max_len))
                      (Z.of_nat (length ctors)) in
@@ -1269,9 +1269,8 @@ Definition make_glue_program
 (* The entry point for glue code generation *)
 Definition generate_glue
            (opts : Options)
-           (p : Ast.program) (* an L1 program *)
+           (globs : Ast.global_env) (* an L1 program *)
            : error (name_env * option Clight.program * option Clight.program * list string) :=
-  let (globs, _) := p in
   let init : gstate_data :=
       {| gstate_gensym := 2%positive
        ; gstate_ienv   := M.empty _

--- a/theories/Glue/glue.v
+++ b/theories/Glue/glue.v
@@ -1270,7 +1270,7 @@ Definition make_glue_program
 Definition generate_glue
            (opts : Options)
            (globs : Ast.global_env) (* an L1 program *)
-           : error (name_env * option Clight.program * option Clight.program * list string) :=
+           : error (name_env * Clight.program * Clight.program * list string) :=
   let init : gstate_data :=
       {| gstate_gensym := 2%positive
        ; gstate_ienv   := M.empty _
@@ -1284,10 +1284,11 @@ Definition generate_glue
   let '(err, st) := runState (make_glue_program (rev globs)) opts init in
   let nenv := gstate_nenv st in
   match err with
-  | Ret (header, source) =>
+  | Err s => Err s
+  | Ret (Some header, Some source) =>
     Ret (nenv (* the name environment to be passed to C generation *) ,
          header (* the header content *),
          source (* the source content *),
          rev (gstate_log st) (* logged messages *))
-  | Err s => Err s
+  | Ret _ => Err "No Clight program generated"
   end.


### PR DESCRIPTION
```
CertiCoq Generate Glue -file "filename" [nat, list, bool].
```
creates `filename.c` and `filename.h` with the glue code for the types listed above. It also works with programs if the user wants to use it that way:
```
CertiCoq Generate Glue -file "filename" [negb].
```
This command creates files that have glue code for the `bool` type.

The `CertiCoq Compile` command still creates `glue.*.{c,h}` files automatically for compiled programs, I'm assuming @zoep doesn't want that, but I wanted to check before I delete that and fix the tests accordingly, hence I didn't push into `clean` automatically and created a PR instead.

(sorry about the trailing whitespace changes, my editor changed that automatically)